### PR TITLE
Simplify buttons to flat string array

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -477,7 +477,7 @@ describe("App", () => {
             action: "send",
             message: "Choose one",
             actionReason: "ok",
-            buttons: [[{ label: "Yes" }, { label: "No" }]],
+            buttons: ["Yes", "No"],
           }),
         ),
       });

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -183,7 +183,7 @@ describe("Orchestrator", () => {
         action: "send",
         message: "Choose",
         actionReason: "ok",
-        buttons: [[{ label: "Yes" }, { label: "No" }], [{ label: "Maybe" }]],
+        buttons: ["Yes", "No", "Maybe"],
       };
       const claude = mockClaude(successResult(output));
       const { orch, responses } = makeOrchestrator(claude);
@@ -191,7 +191,7 @@ describe("Orchestrator", () => {
       orch.handleMessage("hi");
       await waitForProcessing();
 
-      expect(responses[0].buttons).toEqual([[{ label: "Yes" }, { label: "No" }], [{ label: "Maybe" }]]);
+      expect(responses[0].buttons).toEqual(["Yes", "No", "Maybe"]);
     });
 
     it("passes files through onResponse", async () => {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -17,16 +17,12 @@ const backgroundAgentSchema = z.object({
   model: z.enum(["haiku", "sonnet", "opus"]).describe("Model to use for the background agent").optional(),
 });
 
-const buttonSchema = z.object({
-  label: z.string().describe("Button text shown to the user"),
-});
-
 const claudeResponseSchema = z.object({
   action: z.enum(["send", "silent"]).describe("'send' to reply to the user, 'silent' to do nothing"),
   actionReason: z.string().describe("Why the agent chose this action (logged, not sent)"),
   message: z.string().describe("The message to send to Telegram (required when action is 'send')").optional(),
   files: z.array(z.string()).describe("Absolute paths to files to send to Telegram").optional(),
-  buttons: z.array(z.array(buttonSchema)).describe("Inline keyboard rows; each row is an array of buttons").optional(),
+  buttons: z.array(z.string()).describe("Button labels to show below the message").optional(),
   backgroundAgents: z.array(backgroundAgentSchema).describe("Background agents to spawn alongside this response").optional(),
 });
 
@@ -39,7 +35,7 @@ const jsonSchema = JSON.stringify(z.toJSONSchema(claudeResponseSchema, { target:
 export interface OrchestratorResponse {
   message: string;
   files?: string[];
-  buttons?: Array<Array<{ label: string }>>;
+  buttons?: string[];
 }
 
 // --- Internal request types ---

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -44,5 +44,5 @@ On timeout, task continues in background automatically. Spawn background agents 
 
 Cron: jobs in .macroclaw/cron.json (hot-reloaded). Use "silent" when check finds nothing new, "send" when noteworthy.
 
-MessageButtons: include a buttons field (array of rows, each row array of { label }) to attach inline buttons below your message. \
-Shown to the user as tappable buttons alongside the message. Use for quick replies, confirmations, choices.`;
+MessageButtons: include a buttons field (flat array of label strings) to attach inline buttons below your message. \
+Each button gets its own row. Max 27 characters per label — if options need more detail, describe them in the message and use short labels on buttons.`;

--- a/src/telegram.test.ts
+++ b/src/telegram.test.ts
@@ -96,7 +96,7 @@ describe("sendResponse", () => {
 
   it("attaches buttons to a single message", async () => {
     const bot = mockBot();
-    const buttons = [[{ label: "Yes" }, { label: "No" }]];
+    const buttons = ["Yes", "No"];
     await sendResponse(bot, "123", "Choose:", buttons);
     expect(bot.api.sendMessage).toHaveBeenCalledTimes(1);
     expect(bot.calls[0].opts.reply_markup).toBeDefined();
@@ -106,7 +106,7 @@ describe("sendResponse", () => {
     const bot = mockBot();
     const line = "a".repeat(2000);
     const text = `${line}\n${line}\n${line}`;
-    const buttons = [[{ label: "Ok" }]];
+    const buttons = ["Ok"];
     await sendResponse(bot, "123", text, buttons);
     expect(bot.api.sendMessage).toHaveBeenCalledTimes(2);
     // First chunk: no buttons
@@ -125,16 +125,16 @@ describe("sendResponse", () => {
 
 describe("buildInlineKeyboard", () => {
   it("builds keyboard with rows and buttons", () => {
-    const kb = buildInlineKeyboard([[{ label: "A" }, { label: "B" }], [{ label: "C" }]]);
+    const kb = buildInlineKeyboard(["A", "B", "C"]);
     expect(kb).toBeDefined();
     // InlineKeyboard from grammy — verify it's an object with inline_keyboard
     expect(kb.inline_keyboard).toBeDefined();
-    expect(kb.inline_keyboard.length).toBe(2);
-    expect(kb.inline_keyboard[0].length).toBe(2);
+    expect(kb.inline_keyboard.length).toBe(3);
+    expect(kb.inline_keyboard[0].length).toBe(1);
     const btn = kb.inline_keyboard[0][0] as any;
     expect(btn.text).toBe("A");
     expect(btn.callback_data).toBe("A");
-    expect((kb.inline_keyboard[1][0] as any).text).toBe("C");
+    expect((kb.inline_keyboard[2][0] as any).text).toBe("C");
   });
 });
 

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -15,13 +15,11 @@ export function createBot(token: string) {
   return new Bot(token);
 }
 
-export function buildInlineKeyboard(buttons: Array<Array<{ label: string }>>): InlineKeyboard {
+export function buildInlineKeyboard(buttons: string[]): InlineKeyboard {
   const kb = new InlineKeyboard();
   for (let i = 0; i < buttons.length; i++) {
     if (i > 0) kb.row();
-    for (const btn of buttons[i]) {
-      kb.text(btn.label, btn.label);
-    }
+    kb.text(buttons[i], buttons[i]);
   }
   return kb;
 }
@@ -30,7 +28,7 @@ export async function sendResponse(
   bot: Bot,
   chatId: string,
   text: string,
-  buttons?: Array<Array<{ label: string }>>,
+  buttons?: string[],
 ): Promise<void> {
   const opts = { parse_mode: "HTML" as const };
   const replyMarkup = buttons?.length ? buildInlineKeyboard(buttons) : undefined;


### PR DESCRIPTION
## Summary

- Buttons schema changes from `Array<Array<{label}>>` (nested rows) to `Array<string>` (flat list of labels)
- Platform handles layout (one button per row), Claude just provides the labels
- Simpler schema = less for Claude to get wrong, and layout is a platform concern

## Test plan

- [x] All existing tests updated and passing
- [x] 100% coverage maintained