### PR TITLE
Add repository URL for npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary

- Add `repository.url` to `package.json` — required by npm's `--provenance` flag to verify the package was built from this repo

## Test plan

- [ ] Merge and verify the release workflow publishes to npm successfully