### PR TITLE
Add repository URL for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "src/",
     "workspace-template/"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/macrosak/macroclaw"
+  },
   "scripts": {
     "start": "bun run src/index.ts",
     "dev": "bun run --watch src/index.ts",


### PR DESCRIPTION
## Summary

- Add `repository.url` to `package.json` — required by npm's `--provenance` flag to verify the package was built from this repo

## Test plan

- [ ] Merge and verify the release workflow publishes to npm successfully