### PR TITLE
Add background agent detail view with kill

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -556,6 +556,29 @@ describe("App", () => {
       expect((config.claude as Claude & { calls: CallInfo[] }).calls).toHaveLength(0);
     });
 
+    it("handles detail: callback by routing to orchestrator.handleDetail", async () => {
+      const config = makeConfig();
+      const app = new App(config);
+      const bot = app.bot as any;
+      const handler = bot.filterHandlers.get("callback_query:data")![0];
+
+      const ctx = {
+        chat: { id: 12345 },
+        callbackQuery: { data: "detail:test-session-123" },
+        answerCallbackQuery: mock(async () => {}),
+        editMessageReplyMarkup: mock(async () => {}),
+      };
+
+      await handler(ctx);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(ctx.answerCallbackQuery).toHaveBeenCalled();
+      expect(ctx.editMessageReplyMarkup).toHaveBeenCalledWith({ reply_markup: { inline_keyboard: [[{ text: "✓ Opened", callback_data: "_noop" }]] } });
+      const calls = (bot.api.sendMessage as any).mock.calls;
+      const text = calls[calls.length - 1][1];
+      expect(text).toBe("Agent not found or already finished.");
+    });
+
     it("handles peek: callback by routing to orchestrator.handlePeek", async () => {
       const config = makeConfig();
       const app = new App(config);
@@ -574,6 +597,29 @@ describe("App", () => {
 
       expect(ctx.answerCallbackQuery).toHaveBeenCalled();
       expect(ctx.editMessageReplyMarkup).toHaveBeenCalledWith({ reply_markup: { inline_keyboard: [[{ text: "✓ Peeked", callback_data: "_noop" }]] } });
+      const calls = (bot.api.sendMessage as any).mock.calls;
+      const text = calls[calls.length - 1][1];
+      expect(text).toBe("Agent not found or already finished.");
+    });
+
+    it("handles kill: callback by routing to orchestrator.handleKill", async () => {
+      const config = makeConfig();
+      const app = new App(config);
+      const bot = app.bot as any;
+      const handler = bot.filterHandlers.get("callback_query:data")![0];
+
+      const ctx = {
+        chat: { id: 12345 },
+        callbackQuery: { data: "kill:test-session-123" },
+        answerCallbackQuery: mock(async () => {}),
+        editMessageReplyMarkup: mock(async () => {}),
+      };
+
+      await handler(ctx);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(ctx.answerCallbackQuery).toHaveBeenCalled();
+      expect(ctx.editMessageReplyMarkup).toHaveBeenCalledWith({ reply_markup: { inline_keyboard: [[{ text: "✓ Killed", callback_data: "_noop" }]] } });
       const calls = (bot.api.sendMessage as any).mock.calls;
       const text = calls[calls.length - 1][1];
       expect(text).toBe("Agent not found or already finished.");

--- a/src/app.ts
+++ b/src/app.ts
@@ -149,11 +149,27 @@ export class App {
         return;
       }
 
+      if (data.startsWith("detail:")) {
+        const sessionId = data.slice(7);
+        await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [[{ text: "✓ Opened", callback_data: "_noop" }]] } });
+        log.debug({ sessionId }, "Detail requested");
+        this.#orchestrator.handleDetail(sessionId);
+        return;
+      }
+
       if (data.startsWith("peek:")) {
         const sessionId = data.slice(5);
         await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [[{ text: "✓ Peeked", callback_data: "_noop" }]] } });
         log.debug({ sessionId }, "Peek requested");
         this.#orchestrator.handlePeek(sessionId);
+        return;
+      }
+
+      if (data.startsWith("kill:")) {
+        const sessionId = data.slice(5);
+        await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [[{ text: "✓ Killed", callback_data: "_noop" }]] } });
+        log.debug({ sessionId }, "Kill requested");
+        this.#orchestrator.handleKill(sessionId);
         return;
       }
 

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -559,7 +559,7 @@ describe("Orchestrator", () => {
       expect(responses[0].message).toBe("No background agents running.");
     });
 
-    it("includes peek buttons and dismiss when agents are running", async () => {
+    it("includes detail buttons and dismiss when agents are running", async () => {
       saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
       const claude = mockClaude((): RunningQuery<unknown> => ({
         sessionId: `bg-${Date.now()}`,
@@ -578,11 +578,11 @@ describe("Orchestrator", () => {
       const listResponse = responses[responses.length - 1];
       expect(listResponse.message).toContain("long-task");
       expect(listResponse.buttons).toBeDefined();
-      expect(listResponse.buttons!.length).toBe(2); // 1 peek + dismiss
-      const peekBtn = listResponse.buttons![0];
-      expect(typeof peekBtn).toBe("object");
-      expect((peekBtn as any).data).toMatch(/^peek:/);
-      expect((peekBtn as any).text).toContain("long-task");
+      expect(listResponse.buttons!.length).toBe(2); // 1 detail + dismiss
+      const detailBtn = listResponse.buttons![0];
+      expect(typeof detailBtn).toBe("object");
+      expect((detailBtn as any).data).toMatch(/^detail:/);
+      expect((detailBtn as any).text).toContain("long-task");
       expect(listResponse.buttons![1]).toEqual({ text: "Dismiss", data: "_dismiss" });
     });
   });
@@ -624,8 +624,8 @@ describe("Orchestrator", () => {
       orch.handleBackgroundList();
       await waitForProcessing();
       const listResponse = responses[responses.length - 1];
-      const peekBtn = listResponse.buttons![0] as { text: string; data: string };
-      const sessionId = peekBtn.data.slice(5); // strip "peek:"
+      const detailBtn = listResponse.buttons![0] as { text: string; data: string };
+      const sessionId = detailBtn.data.slice(7); // strip "detail:"
 
       await orch.handlePeek(sessionId);
       await waitForProcessing();
@@ -663,14 +663,196 @@ describe("Orchestrator", () => {
       orch.handleBackgroundList();
       await waitForProcessing();
       const listResponse = responses[responses.length - 1];
-      const peekBtn = listResponse.buttons![0] as { text: string; data: string };
-      const sessionId = peekBtn.data.slice(5);
+      const detailBtn = listResponse.buttons![0] as { text: string; data: string };
+      const sessionId = detailBtn.data.slice(7); // strip "detail:"
 
       await orch.handlePeek(sessionId);
       await waitForProcessing();
 
       const messages = responses.map((r) => r.message);
       expect(messages.some((m) => m.includes("Couldn't peek at"))).toBe(true);
+    });
+  });
+
+  describe("handleDetail", () => {
+    it("returns 'not found' for unknown sessionId", async () => {
+      const claude = mockClaude({ action: "send", message: "ok", actionReason: "ok" });
+      const { orch, responses } = makeOrchestrator(claude);
+
+      orch.handleDetail("nonexistent-session");
+      await waitForProcessing();
+
+      expect(responses[0].message).toBe("Agent not found or already finished.");
+    });
+
+    it("shows agent details with peek/kill/dismiss buttons", async () => {
+      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      const claude = mockClaude((): RunningQuery<unknown> => ({
+        sessionId: "bg-sid",
+        startedAt: new Date(),
+        result: new Promise(() => {}),
+        kill: mock(async () => {}),
+      }));
+      const { orch, responses } = makeOrchestrator(claude);
+
+      orch.handleBackgroundCommand("research pricing");
+      await waitForProcessing();
+
+      orch.handleBackgroundList();
+      await waitForProcessing();
+      const listResponse = responses[responses.length - 1];
+      const detailBtn = listResponse.buttons![0] as { text: string; data: string };
+      const sessionId = detailBtn.data.slice(7);
+
+      orch.handleDetail(sessionId);
+      await waitForProcessing();
+
+      const detailResponse = responses[responses.length - 1];
+      expect(detailResponse.message).toContain("research-pricing");
+      expect(detailResponse.message).toContain("research pricing");
+      expect(detailResponse.message).toContain("default");
+      expect(detailResponse.message).toContain("Status: running");
+      expect(detailResponse.buttons).toHaveLength(3);
+      expect(detailResponse.buttons![0]).toEqual({ text: "Peek", data: `peek:${sessionId}` });
+      expect(detailResponse.buttons![1]).toEqual({ text: "Kill", data: `kill:${sessionId}` });
+      expect(detailResponse.buttons![2]).toEqual({ text: "Dismiss", data: "_dismiss" });
+    });
+
+    it("truncates prompt at 300 chars", async () => {
+      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      const longPrompt = "a".repeat(500);
+      const claude = mockClaude((): RunningQuery<unknown> => ({
+        sessionId: "bg-sid",
+        startedAt: new Date(),
+        result: new Promise(() => {}),
+        kill: mock(async () => {}),
+      }));
+      const { orch, responses } = makeOrchestrator(claude);
+
+      orch.handleBackgroundCommand(longPrompt);
+      await waitForProcessing();
+
+      orch.handleBackgroundList();
+      await waitForProcessing();
+      const listResponse = responses[responses.length - 1];
+      const detailBtn = listResponse.buttons![0] as { text: string; data: string };
+      const sessionId = detailBtn.data.slice(7);
+
+      orch.handleDetail(sessionId);
+      await waitForProcessing();
+
+      const detailResponse = responses[responses.length - 1];
+      // 300 chars + ellipsis
+      expect(detailResponse.message).toContain("a".repeat(300));
+      expect(detailResponse.message).toContain("…");
+      expect(detailResponse.message).not.toContain("a".repeat(301));
+    });
+
+    it("shows model when specified", async () => {
+      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      const claude = mockClaude((): RunningQuery<unknown> => ({
+        sessionId: "bg-sid",
+        startedAt: new Date(),
+        result: new Promise(() => {}),
+        kill: mock(async () => {}),
+      }));
+      const { orch, responses } = makeOrchestrator(claude, { model: "opus" });
+
+      orch.handleBackgroundCommand("research");
+      await waitForProcessing();
+
+      orch.handleBackgroundList();
+      await waitForProcessing();
+      const listResponse = responses[responses.length - 1];
+      const detailBtn = listResponse.buttons![0] as { text: string; data: string };
+      const sessionId = detailBtn.data.slice(7);
+
+      orch.handleDetail(sessionId);
+      await waitForProcessing();
+
+      const detailResponse = responses[responses.length - 1];
+      expect(detailResponse.message).toContain("Model: opus");
+    });
+  });
+
+  describe("handleKill", () => {
+    it("returns 'not found' for unknown sessionId", async () => {
+      const claude = mockClaude({ action: "send", message: "ok", actionReason: "ok" });
+      const { orch, responses } = makeOrchestrator(claude);
+
+      await orch.handleKill("nonexistent-session");
+      await waitForProcessing();
+
+      expect(responses[0].message).toBe("Agent not found or already finished.");
+    });
+
+    it("kills running agent and sends confirmation", async () => {
+      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      const killMock = mock(async () => {});
+      const claude = mockClaude((): RunningQuery<unknown> => ({
+        sessionId: "bg-sid",
+        startedAt: new Date(),
+        result: new Promise(() => {}),
+        kill: killMock,
+      }));
+      const { orch, responses } = makeOrchestrator(claude);
+
+      orch.handleBackgroundCommand("research pricing");
+      await waitForProcessing();
+
+      orch.handleBackgroundList();
+      await waitForProcessing();
+      const listResponse = responses[responses.length - 1];
+      const detailBtn = listResponse.buttons![0] as { text: string; data: string };
+      const sessionId = detailBtn.data.slice(7);
+
+      await orch.handleKill(sessionId);
+      await waitForProcessing();
+
+      expect(killMock).toHaveBeenCalled();
+      const killResponse = responses[responses.length - 1];
+      expect(killResponse.message).toContain("Killed");
+      expect(killResponse.message).toContain("research-pricing");
+
+      // Agent should be removed from list
+      orch.handleBackgroundList();
+      await waitForProcessing();
+      expect(responses[responses.length - 1].message).toBe("No background agents running.");
+    });
+
+    it("does not feed error back to queue after kill", async () => {
+      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      let rejectBg: (err: Error) => void;
+      const bgResult = new Promise<never>((_, r) => { rejectBg = r; });
+      const claude = mockClaude((): RunningQuery<unknown> => ({
+        sessionId: "bg-sid",
+        startedAt: new Date(),
+        result: bgResult,
+        kill: mock(async () => {}),
+      }));
+      const { orch, responses } = makeOrchestrator(claude);
+
+      orch.handleBackgroundCommand("task");
+      await waitForProcessing();
+
+      orch.handleBackgroundList();
+      await waitForProcessing();
+      const listResponse = responses[responses.length - 1];
+      const detailBtn = listResponse.buttons![0] as { text: string; data: string };
+      const sessionId = detailBtn.data.slice(7);
+
+      await orch.handleKill(sessionId);
+      await waitForProcessing();
+      const countAfterKill = responses.length;
+
+      // Simulate the bg process rejecting after kill
+      rejectBg!(new Error("process killed"));
+      await waitForProcessing(100);
+
+      // No additional error responses should have been added
+      // Only the "Killed" message, no "[Error]" from the bg handler
+      const newResponses = responses.slice(countAfterKill);
+      expect(newResponses.every((r) => !r.message.includes("[Error]"))).toBe(true);
     });
   });
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -67,8 +67,9 @@ function escapeHtml(text: string): string {
 
 interface BackgroundInfo {
   name: string;
-  sessionId: string;
-  startTime: Date;
+  prompt: string;
+  model?: string;
+  query: RunningQuery<AgentOutput>;
 }
 
 export interface OrchestratorConfig {
@@ -123,15 +124,39 @@ export class Orchestrator {
       return;
     }
     const lines = agents.map((a) => {
-      const elapsed = Math.round((Date.now() - a.startTime.getTime()) / 1000);
+      const elapsed = Math.round((Date.now() - a.query.startedAt.getTime()) / 1000);
       return `- ${escapeHtml(a.name)} (${elapsed}s)`;
     });
     const buttons: ButtonSpec[] = agents.map((a) => {
-      const elapsed = Math.round((Date.now() - a.startTime.getTime()) / 1000);
+      const elapsed = Math.round((Date.now() - a.query.startedAt.getTime()) / 1000);
       const text = `${a.name} (${elapsed}s)`.slice(0, 27);
-      return { text, data: `peek:${a.sessionId}` };
+      return { text, data: `detail:${a.query.sessionId}` };
     });
     buttons.push({text: "Dismiss", data: "_dismiss"});
+    this.#callOnResponse({ message: lines.join("\n"), buttons });
+  }
+
+  handleDetail(sessionId: string): void {
+    const agent = this.#backgroundAgents.get(sessionId);
+    if (!agent) {
+      this.#callOnResponse({ message: "Agent not found or already finished." });
+      return;
+    }
+
+    const elapsed = Math.round((Date.now() - agent.query.startedAt.getTime()) / 1000);
+    const truncatedPrompt = agent.prompt.length > 300 ? `${agent.prompt.slice(0, 300)}…` : agent.prompt;
+    const lines = [
+      `<b>${escapeHtml(agent.name)}</b>`,
+      `Prompt: ${escapeHtml(truncatedPrompt)}`,
+      `Model: ${agent.model ?? "default"}`,
+      `Elapsed: ${elapsed}s`,
+      "Status: running",
+    ];
+    const buttons: ButtonSpec[] = [
+      { text: "Peek", data: `peek:${sessionId}` },
+      { text: "Kill", data: `kill:${sessionId}` },
+      { text: "Dismiss", data: "_dismiss" },
+    ];
     this.#callOnResponse({ message: lines.join("\n"), buttons });
   }
 
@@ -156,6 +181,24 @@ export class Orchestrator {
     } catch (err) {
       this.#callOnResponse({ message: `Couldn't peek at ${escapeHtml(agent.name)}: ${err}` });
     }
+  }
+
+  async handleKill(sessionId: string): Promise<void> {
+    const agent = this.#backgroundAgents.get(sessionId);
+    if (!agent) {
+      this.#callOnResponse({ message: "Agent not found or already finished." });
+      return;
+    }
+
+    this.#backgroundAgents.delete(sessionId);
+
+    try {
+      await agent.query.kill();
+    } catch (err) {
+      log.error({ err, name: agent.name }, "Kill failed");
+    }
+
+    this.#callOnResponse({ message: `Killed <b>${escapeHtml(agent.name)}</b>.` });
   }
 
   handleSessionCommand(): void {
@@ -298,9 +341,11 @@ export class Orchestrator {
     const name = request.type === "user" ? request.message.slice(0, 30).replace(/\s+/g, "-")
       : request.type === "cron" ? `cron-${request.name}`
       : "task";
+    const prompt = this.#formatPrompt(request);
+    const model = request.type === "cron" ? (request.model ?? this.#config.model) : this.#config.model;
     log.info({ name, sessionId: query.sessionId }, "Request backgrounded due to timeout");
     this.#callOnResponse({ message: "This is taking longer, continuing in the background." });
-    this.#adoptBackground(name, query.sessionId, query.startedAt, query.result);
+    this.#adoptBackground(name, prompt, model, query);
     return null;
   }
 
@@ -327,18 +372,20 @@ export class Orchestrator {
       ? this.#claude.forkSession(this.#mainSessionId, bgPrompt, responseResultType, { model })
       : this.#claude.newSession(bgPrompt, responseResultType, { model });
     const sessionId = query.sessionId;
-    const info: BackgroundInfo = { name, sessionId, startTime: query.startedAt };
+    const info: BackgroundInfo = { name, prompt, model, query };
     this.#backgroundAgents.set(sessionId, info);
 
     log.debug({ name, sessionId }, "Starting background agent");
 
     query.result.then(
       async ({ value: response }) => {
+        if (!this.#backgroundAgents.has(sessionId)) return;
         this.#backgroundAgents.delete(sessionId);
         log.debug({ name, message: response.message }, "Background agent finished");
         this.#queue.push({ type: "background-agent-result", name, response });
       },
       (err) => {
+        if (!this.#backgroundAgents.has(sessionId)) return;
         this.#backgroundAgents.delete(sessionId);
         log.error({ name, err }, "Background agent failed");
         this.#queue.push({ type: "background-agent-result", name, response: { action: "send", message: `[Error] ${err}`, actionReason: "bg-agent-failed" } });
@@ -346,19 +393,22 @@ export class Orchestrator {
     );
   }
 
-  #adoptBackground(name: string, sessionId: string, startTime: Date, completion: Promise<QueryResult<AgentOutput>>) {
-    const info: BackgroundInfo = { name, sessionId, startTime };
+  #adoptBackground(name: string, prompt: string, model: string | undefined, query: RunningQuery<AgentOutput>) {
+    const sessionId = query.sessionId;
+    const info: BackgroundInfo = { name, prompt, model, query };
     this.#backgroundAgents.set(sessionId, info);
 
     log.debug({ name, sessionId }, "Adopting backgrounded task");
 
-    completion.then(
+    query.result.then(
       ({ value: response }) => {
+        if (!this.#backgroundAgents.has(sessionId)) return;
         this.#backgroundAgents.delete(sessionId);
         log.debug({ name }, "Adopted task finished");
         this.#queue.push({ type: "background-agent-result", name, response, sessionId });
       },
       (err) => {
+        if (!this.#backgroundAgents.has(sessionId)) return;
         this.#backgroundAgents.delete(sessionId);
         log.error({ name, err }, "Adopted task failed");
         this.#queue.push({ type: "background-agent-result", name, response: { action: "send", message: `[Error] ${err}`, actionReason: "deferred-failed" }, sessionId });


### PR DESCRIPTION
## Summary
- Clicking an agent in `/bg-list` now opens a detail view (name, prompt truncated to 300 chars, model, elapsed time, status) instead of immediately peeking
- Detail view has Peek, Kill, and Dismiss buttons
- Kill gracefully terminates the background agent process and suppresses post-kill error notifications
- `BackgroundInfo` now stores the full `RunningQuery` + prompt/model instead of duplicating sessionId/startTime

Closes #30

## Test plan
- [x] `bun run check` passes (293 tests, 100% line coverage, no lint/dep issues)
- [x] Manual test: spawn `/bg do something`, then `/bg` to list, tap agent → detail view appears
- [x] Manual test: tap Peek from detail → status summary arrives
- [x] Manual test: tap Kill from detail → agent terminated, confirmation sent