### PR TITLE
Include start time in peek prompt

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -170,9 +170,10 @@ export class Orchestrator {
     this.#callOnResponse({ message: `Peeking at <b>${escapeHtml(agent.name)}</b>...` });
 
     try {
+      const startedAt = agent.query.startedAt.toISOString();
       const query = this.#claude.forkSession(
         sessionId,
-        "Give a brief status update: what has been done so far, what's currently happening, and what's remaining. 2-3 sentences max.",
+        `This session started at ${startedAt}. Only consider events after that time. Give a brief status update: what has been done so far, what's currently happening, and what's remaining. 2-3 sentences max.`,
         textResultType,
         { model: "haiku" },
       );


### PR DESCRIPTION
- Add session start time to the peek fork prompt so the peeking model only reports on events after the session began
- Prevents peek from summarizing the full conversation history prior to the background task