### PR TITLE
Add Docker container support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.env
+.git
+docs.local
+*.test.ts
+*.integration-test.ts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM oven/bun:latest
+
+ARG VERSION=latest
+
+RUN apt-get update && apt-get install -y curl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN useradd -m -s /bin/bash macroclaw
+USER macroclaw
+WORKDIR /home/macroclaw
+
+# Override oven/bun default which points to /usr/local/bin (root-owned)
+ENV BUN_INSTALL_BIN="/home/macroclaw/.bun/bin"
+
+# Install Claude Code CLI (standalone binary, installs to ~/.local/bin)
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+# Install macroclaw from npm
+RUN bun install -g macroclaw@${VERSION}
+
+ENV PATH="/home/macroclaw/.local/bin:${BUN_INSTALL_BIN}:$PATH"
+
+ENTRYPOINT ["macroclaw"]
+CMD ["start"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,25 @@
+FROM oven/bun:latest
+
+RUN apt-get update && apt-get install -y curl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN useradd -m -s /bin/bash macroclaw
+USER macroclaw
+WORKDIR /home/macroclaw/app
+
+# Install Claude Code CLI (standalone binary, installs to ~/.local/bin)
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+# Install macroclaw from local source
+COPY --chown=macroclaw:macroclaw package.json bun.lock ./
+RUN bun install --frozen-lockfile --production
+COPY --chown=macroclaw:macroclaw bin/ bin/
+COPY --chown=macroclaw:macroclaw src/ src/
+COPY --chown=macroclaw:macroclaw workspace-template/ workspace-template/
+RUN ln -s /home/macroclaw/app/bin/macroclaw.js /home/macroclaw/.local/bin/macroclaw
+
+ENV PATH="/home/macroclaw/.local/bin:/home/macroclaw/app/node_modules/.bin:$PATH"
+
+ENTRYPOINT ["macroclaw"]
+CMD ["start"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A lightweight bridge that turns a Telegram chat into a personal AI assistant —
 Macroclaw runs with `dangerouslySkipPermissions` enabled. This is intentional — the bot
 is designed to run in an isolated environment (container or VM) where the workspace is
 the entire world. The single authorized chat ID ensures only one user can interact with
-the bot.
+the bot. See [Docker](#docker) for the recommended containerized setup.
 
 ## Requirements
 
@@ -55,6 +55,8 @@ Session state (Claude session IDs) is stored separately in `~/.macroclaw/session
 
 ## Commands
 
+Run `macroclaw --help` or `macroclaw <command> --help` for the complete reference.
+
 | Command | Description |
 |---------|-------------|
 | `macroclaw start` | Start the bridge |
@@ -79,6 +81,43 @@ macroclaw service install
 Both paths install macroclaw globally via `bun install -g`, register it as a **launchd** agent (macOS) or **systemd** unit (Linux) with auto-restart, and start the bridge.
 
 On Linux, the command runs as a normal user. Only the privileged operations (writing to `/etc/systemd/system/`, systemctl commands) are elevated via `sudo`, which prompts for a password when needed. Package installation and path resolution stay in the user's environment.
+
+## Docker
+
+Run macroclaw in a Docker container. The workspace is bind-mounted from the host; everything else (settings, Claude auth, sessions) lives in a named Docker volume.
+
+```bash
+# 1. Login to Claude Code (one-time, interactive — use /login inside the session)
+docker compose run --rm -w /workspace --entrypoint claude macroclaw
+
+# 2. Setup macroclaw (one-time, interactive — bot token, chat ID, model)
+docker compose run --rm macroclaw setup --skip-service
+
+# 3. Start the bridge
+docker compose up -d
+```
+
+The `WORKSPACE` env var is pre-set in `docker-compose.yml` so you don't need to configure the workspace path during setup. The `--skip-service` flag skips the service installation prompt (not applicable in Docker).
+
+To build a specific version:
+
+```bash
+docker compose build --build-arg VERSION=0.18.0
+```
+
+To reset everything (remove containers, volumes, and images):
+
+```bash
+docker compose down -v --rmi all
+```
+
+### Development with Docker
+
+Use `Dockerfile.dev` to build from local source instead of the published npm package:
+
+```bash
+docker compose -f docker-compose.dev.yml up -d
+```
 
 ## Development
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,15 @@
+services:
+  macroclaw:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    container_name: macroclaw
+    restart: unless-stopped
+    volumes:
+      - macroclaw-home:/home/macroclaw
+      - ~/.macroclaw-workspace:/workspace
+    environment:
+      - WORKSPACE=/workspace
+
+volumes:
+  macroclaw-home:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  macroclaw:
+    build: .
+    container_name: macroclaw
+    restart: unless-stopped
+    volumes:
+      - macroclaw-home:/home/macroclaw
+      - ~/.macroclaw-workspace:/workspace
+    environment:
+      - WORKSPACE=/workspace
+
+volumes:
+  macroclaw-home:

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -18,10 +18,11 @@ mock.module("node:child_process", () => ({
 
 const { main } = await import("./cli");
 
-function createMockWizard(overrides?: { collectSettings?: (defaults?: Record<string, unknown>) => Promise<unknown>; installService?: () => Promise<void> }) {
+function createMockWizard(overrides?: { collectSettings?: (defaults?: Record<string, unknown>) => Promise<unknown>; installService?: () => Promise<void>; forceInstallService?: () => Promise<void> }) {
 	return {
 		collectSettings: overrides?.collectSettings ?? mock(async () => ({ botToken: "tok", chatId: "123" })),
 		installService: overrides?.installService ?? mock(async () => {}),
+		forceInstallService: overrides?.forceInstallService ?? mock(async () => {}),
 	} as unknown as SetupWizard;
 }
 
@@ -92,6 +93,23 @@ describe("Cli.setup", () => {
 		await cli.setup();
 		expect((wizard.collectSettings as ReturnType<typeof mock>)).toHaveBeenCalled();
 		expect((wizard.installService as ReturnType<typeof mock>)).toHaveBeenCalled();
+	});
+
+	it("skips service install when --skip-service is set", async () => {
+		const wizard = createMockWizard();
+		const cli = new Cli({ wizard, settings: createMockSettings() });
+		await cli.setup({ skipService: true });
+		expect((wizard.collectSettings as ReturnType<typeof mock>)).toHaveBeenCalled();
+		expect((wizard.installService as ReturnType<typeof mock>)).not.toHaveBeenCalled();
+	});
+
+	it("force installs service when --install-service is set", async () => {
+		const forceInstallService = mock(async () => {});
+		const wizard = { ...createMockWizard(), forceInstallService } as unknown as SetupWizard;
+		const cli = new Cli({ wizard, settings: createMockSettings() });
+		await cli.setup({ installService: true });
+		expect(forceInstallService).toHaveBeenCalled();
+		expect((wizard.installService as ReturnType<typeof mock>)).not.toHaveBeenCalled();
 	});
 
 	it("creates default wizard when none provided", () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,10 +18,15 @@ export class Cli {
 		this.#serviceManager = opts?.systemService ?? new SystemServiceManager();
 	}
 
-	async setup(): Promise<void> {
+	async setup(opts?: { skipService?: boolean; installService?: boolean }): Promise<void> {
 		const defaults = this.#settingsManager.loadRaw() ?? undefined;
 		const settings = await this.#setupWizard.collectSettings(defaults);
 		this.#settingsManager.save(settings);
+		if (opts?.skipService) return;
+		if (opts?.installService) {
+			await this.#setupWizard.forceInstallService();
+			return;
+		}
 		await this.#setupWizard.installService();
 	}
 
@@ -123,7 +128,11 @@ const startCommand = defineCommand({
 
 const setupCommand = defineCommand({
 	meta: { name: "setup", description: "Run the interactive setup wizard" },
-	run: () => defaultCli.setup().catch(handleError),
+	args: {
+		"skip-service": { type: "boolean", description: "Skip the service installation prompt" },
+		"install-service": { type: "boolean", description: "Install as a system service without prompting" },
+	},
+	run: ({ args }) => defaultCli.setup({ skipService: args["skip-service"], installService: args["install-service"] }).catch(handleError),
 });
 
 const claudeCommand = defineCommand({

--- a/src/setup.test.ts
+++ b/src/setup.test.ts
@@ -383,6 +383,31 @@ it("installs service when user answers yes", async () => {
     expect(io.written).toContainEqual(expect.stringContaining("Service installation failed: Permission denied"));
   });
 
+  it("forceInstallService installs without prompting", async () => {
+    mockInstall.mockClear();
+    const installer = createMockServiceInstaller();
+    const io = createMockIO([
+      "sk-test-token",  // oauth token (macOS)
+    ]);
+
+    const wizard = new SetupWizard(io, { serviceInstaller: installer, platform: "darwin" });
+    await wizard.forceInstallService();
+
+    expect(mockInstall).toHaveBeenCalled();
+    expect(io.written).toContainEqual(expect.stringContaining("Service installed and started."));
+  });
+
+  it("forceInstallService skips on Linux without prompting", async () => {
+    mockInstall.mockClear();
+    const installer = createMockServiceInstaller();
+    const io = createMockIO([]);
+
+    const wizard = new SetupWizard(io, { serviceInstaller: installer, platform: "linux" });
+    await wizard.forceInstallService();
+
+    expect(mockInstall).toHaveBeenCalled();
+  });
+
   it("fails fast when claude CLI is not found", async () => {
     mockExecSync.mockImplementation(() => { throw new Error("not found"); });
     const io = createMockIO([]);

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -116,26 +116,39 @@ export class SetupWizard {
       const installAnswer = await this.#io.ask("Install as a system service? [Y/n]: ");
       if (installAnswer.toLowerCase() === "n" || installAnswer.toLowerCase() === "no") return;
 
-      let oauthToken: string | undefined;
-      if (this.#platform === "darwin") {
-        this.#io.write("\nmacOS requires a long-lived OAuth token for the service.\n");
-        this.#io.write("Run `claude setup-token` in another terminal, then paste the token here.\n\n");
-        oauthToken = await this.#io.ask("OAuth token: ");
-        if (!oauthToken) {
-          this.#io.write("No token provided. Skipping service installation.\n");
-          return;
-        }
-      }
-
-      try {
-        const svc = this.#serviceInstaller ?? new (await import("./system-service")).SystemServiceManager();
-        const logCmd = svc.install(oauthToken);
-        this.#io.write(`Service installed and started. Check logs:\n  ${logCmd}\n`);
-      } catch (err) {
-        this.#io.write(`Service installation failed: ${(err as Error).message}\n`);
-      }
+      await this.#doInstallService();
     } finally {
       this.#io.close();
+    }
+  }
+
+  async forceInstallService(): Promise<void> {
+    this.#io.open();
+    try {
+      await this.#doInstallService();
+    } finally {
+      this.#io.close();
+    }
+  }
+
+  async #doInstallService(): Promise<void> {
+    let oauthToken: string | undefined;
+    if (this.#platform === "darwin") {
+      this.#io.write("\nmacOS requires a long-lived OAuth token for the service.\n");
+      this.#io.write("Run `claude setup-token` in another terminal, then paste the token here.\n\n");
+      oauthToken = await this.#io.ask("OAuth token: ");
+      if (!oauthToken) {
+        this.#io.write("No token provided. Skipping service installation.\n");
+        return;
+      }
+    }
+
+    try {
+      const svc = this.#serviceInstaller ?? new (await import("./system-service")).SystemServiceManager();
+      const logCmd = svc.install(oauthToken);
+      this.#io.write(`Service installed and started. Check logs:\n  ${logCmd}\n`);
+    } catch (err) {
+      this.#io.write(`Service installation failed: ${(err as Error).message}\n`);
     }
   }
 


### PR DESCRIPTION
## Summary

- Add `Dockerfile` (published npm package) and `Dockerfile.dev` (local source) with separate docker-compose files
- Add `--skip-service` and `--install-service` flags to `macroclaw setup`
- Document Docker setup flow in README

Closes #34