### PR TITLE
Fire missed non-recurring events regardless of delay

### DIFF
--- a/src/cron.test.ts
+++ b/src/cron.test.ts
@@ -254,7 +254,7 @@ describe("CronScheduler", () => {
 
   it("does not write file when no non-recurring jobs fired", () => {
     writeScheduleConfig({
-      jobs: [{ name: "recurring", cron: nonMatchingCron(), prompt: "nope", recurring: false }],
+      jobs: [{ name: "recurring", cron: nonMatchingCron(), prompt: "nope" }],
     });
 
     const onJob = makeOnJob();
@@ -318,9 +318,9 @@ describe("missed non-recurring events", () => {
     expect(onJob).not.toHaveBeenCalled();
   });
 
-  it("does not fire non-recurring jobs older than threshold", () => {
+  it("fires non-recurring job missed by more than 5 minutes", () => {
     writeScheduleConfig({
-      jobs: [{ name: "old", cron: minutesAgoCron(10), prompt: "too late", recurring: false }],
+      jobs: [{ name: "old", cron: minutesAgoCron(10), prompt: "still fires", recurring: false }],
     });
 
     const onJob = makeOnJob();
@@ -328,8 +328,13 @@ describe("missed non-recurring events", () => {
     cron.start();
     cron.stop();
 
-    expect(onJob).not.toHaveBeenCalled();
+    expect(onJob).toHaveBeenCalledTimes(1);
+    const call = onJob.mock.calls[0];
+    expect(call[0]).toBe("old");
+    expect(call[1]).toContain("[missed event, should have fired");
+    expect(call[1]).toContain("still fires");
+
     const updated = readScheduleConfig();
-    expect(updated.jobs).toHaveLength(1);
+    expect(updated.jobs).toHaveLength(0);
   });
 });

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -25,7 +25,6 @@ export interface CronSchedulerConfig {
 }
 
 const TICK_INTERVAL = 10_000; // 10 seconds
-const MISSED_THRESHOLD = 300_000; // 5 minutes
 
 export class CronScheduler {
   #lastMinute = -1;
@@ -88,8 +87,8 @@ export class CronScheduler {
           if (job.recurring === false) {
             firedNonRecurring.push(i);
           }
-        } else if (job.recurring === false && diff < MISSED_THRESHOLD) {
-          // Non-recurring job missed (service was down) — fire with missed prefix
+        } else if (job.recurring === false && diff >= 60_000) {
+          // Non-recurring job in the past — fire regardless of how late
           const missedMinutes = Math.round(diff / 60_000);
           const firedAt = prev.toISOString();
           const missedPrompt = `[missed event, should have fired ${missedMinutes} min ago at ${firedAt}] ${job.prompt}`;


### PR DESCRIPTION
## Summary
- Remove the 5-minute missed threshold for non-recurring cron events
- One-shot events now always fire if their time has passed, with a `[missed event]` prefix
- Prevents silently dropping events when the service was down or the schedule was written late

## Test plan
- [x] Existing tests updated — "fires non-recurring job missed by more than 5 minutes" replaces the old threshold test
- [x] `bun run check` passes (typecheck, lint, 301 tests, 100% line coverage, depcheck)