### PR TITLE
Cap missed non-recurring cron jobs to 1 week

### DIFF
--- a/src/cron.test.ts
+++ b/src/cron.test.ts
@@ -39,6 +39,12 @@ function minutesAgoCron(minutesAgo: number): string {
   return `${past.getMinutes()} ${past.getHours()} ${past.getDate()} ${past.getMonth() + 1} *`;
 }
 
+// Build a cron expression that matched N days ago
+function daysAgoCron(daysAgo: number): string {
+  const past = new Date(Date.now() - daysAgo * 24 * 60 * 60_000);
+  return `${past.getMinutes()} ${past.getHours()} ${past.getDate()} ${past.getMonth() + 1} *`;
+}
+
 beforeEach(() => {
   mkdirSync(SCHEDULE_DIR, { recursive: true });
 });
@@ -336,5 +342,42 @@ describe("missed non-recurring events", () => {
 
     const updated = readScheduleConfig();
     expect(updated.jobs).toHaveLength(0);
+  });
+
+  it("discards non-recurring job missed by more than a week without firing", () => {
+    writeScheduleConfig({
+      jobs: [
+        { name: "stale", cron: daysAgoCron(10), prompt: "too old", recurring: false },
+        { name: "keeper", cron: nonMatchingCron(), prompt: "stay" },
+      ],
+    });
+
+    const onJob = makeOnJob();
+    const cron = new CronScheduler(TEST_DIR, { onJob });
+    cron.start();
+    cron.stop();
+
+    expect(onJob).not.toHaveBeenCalled();
+
+    const updated = readScheduleConfig();
+    expect(updated.jobs).toHaveLength(1);
+    expect(updated.jobs[0].name).toBe("keeper");
+  });
+
+  it("fires non-recurring job missed by 6 days (within week window)", () => {
+    writeScheduleConfig({
+      jobs: [{ name: "recent", cron: daysAgoCron(6), prompt: "still valid", recurring: false }],
+    });
+
+    const onJob = makeOnJob();
+    const cron = new CronScheduler(TEST_DIR, { onJob });
+    cron.start();
+    cron.stop();
+
+    expect(onJob).toHaveBeenCalledTimes(1);
+    const call = onJob.mock.calls[0];
+    expect(call[0]).toBe("recent");
+    expect(call[1]).toContain("[missed event, should have fired");
+    expect(call[1]).toContain("still valid");
   });
 });

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -25,6 +25,7 @@ export interface CronSchedulerConfig {
 }
 
 const TICK_INTERVAL = 10_000; // 10 seconds
+const MAX_MISSED_MS = 7 * 24 * 60 * 60 * 1000; // 1 week
 
 export class CronScheduler {
   #lastMinute = -1;
@@ -87,13 +88,17 @@ export class CronScheduler {
           if (job.recurring === false) {
             firedNonRecurring.push(i);
           }
-        } else if (job.recurring === false && diff >= 60_000) {
-          // Non-recurring job in the past — fire regardless of how late
+        } else if (job.recurring === false && diff >= 60_000 && diff <= MAX_MISSED_MS) {
+          // Non-recurring job in the past — fire if missed within the last week
           const missedMinutes = Math.round(diff / 60_000);
           const firedAt = prev.toISOString();
           const missedPrompt = `[missed event, should have fired ${missedMinutes} min ago at ${firedAt}] ${job.prompt}`;
           log.info({ name: job.name, missedMinutes, firedAt }, "Firing missed non-recurring job");
           this.#config.onJob(job.name, missedPrompt, job.model);
+          firedNonRecurring.push(i);
+        } else if (job.recurring === false && diff > MAX_MISSED_MS) {
+          // Non-recurring job missed by more than a week — discard without firing
+          log.warn({ name: job.name, missedMinutes: Math.round(diff / 60_000) }, "Discarding stale non-recurring job");
           firedNonRecurring.push(i);
         }
       } catch (err) {


### PR DESCRIPTION
## Summary
- Non-recurring cron jobs missed by more than 7 days are now silently discarded instead of firing
- Fixes false firings where `cron-parser`'s `prev()` returns a year-old occurrence because cron expressions don't encode a year (e.g. `0 8 16 3 *` on March 15 returns March 16 of the previous year)

## Test plan
- [x] Existing missed-job tests still pass (3 min, 10 min delays)
- [x] New test: job missed by 10 days is discarded without firing
- [x] New test: job missed by 6 days still fires (within window)
- [x] `bun run check` passes (typecheck + lint + tests + depcheck)