### PR TITLE
Don't discard upcoming non-recurring cron jobs

### DIFF
--- a/src/cron.test.ts
+++ b/src/cron.test.ts
@@ -364,6 +364,29 @@ describe("missed non-recurring events", () => {
     expect(updated.jobs[0].name).toBe("keeper");
   });
 
+  it("keeps non-recurring job whose next occurrence is within a week", () => {
+    // Simulates timezone mismatch: prev() returns last year but next() is today/soon
+    const future = new Date(Date.now() + 3 * 60 * 60_000); // 3 hours from now
+    const futureCron = `${future.getMinutes()} ${future.getHours()} ${future.getDate()} ${future.getMonth() + 1} *`;
+
+    writeScheduleConfig({
+      jobs: [{ name: "upcoming", cron: futureCron, prompt: "soon", recurring: false }],
+    });
+
+    const onJob = makeOnJob();
+    const cron = new CronScheduler(TEST_DIR, { onJob });
+    cron.start();
+    cron.stop();
+
+    // Should not fire — it's upcoming, not missed
+    expect(onJob).not.toHaveBeenCalled();
+
+    // Should still be in schedule.json
+    const updated = readScheduleConfig();
+    expect(updated.jobs).toHaveLength(1);
+    expect(updated.jobs[0].name).toBe("upcoming");
+  });
+
   it("fires non-recurring job missed by 6 days (within week window)", () => {
     writeScheduleConfig({
       jobs: [{ name: "recent", cron: daysAgoCron(6), prompt: "still valid", recurring: false }],

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -97,9 +97,19 @@ export class CronScheduler {
           this.#config.onJob(job.name, missedPrompt, job.model);
           firedNonRecurring.push(i);
         } else if (job.recurring === false && diff > MAX_MISSED_MS) {
-          // Non-recurring job missed by more than a week — discard without firing
-          log.warn({ name: job.name, missedMinutes: Math.round(diff / 60_000) }, "Discarding stale non-recurring job");
-          firedNonRecurring.push(i);
+          // prev() returned a far-past date — check if it's actually upcoming
+          // (timezone can cause prev() to skip to last year if today's occurrence hasn't passed in local time)
+          const nextInterval = CronExpressionParser.parse(job.cron);
+          const nextOccurrence = nextInterval.next();
+          const nextDiff = Math.abs(now.getTime() - nextOccurrence.getTime());
+          if (nextDiff <= MAX_MISSED_MS) {
+            // Next occurrence is soon — job is upcoming, keep it
+            log.debug({ name: job.name }, "Non-recurring job upcoming, skipping");
+          } else {
+            // Truly stale — discard without firing
+            log.warn({ name: job.name, missedMinutes: Math.round(diff / 60_000) }, "Discarding stale non-recurring job");
+            firedNonRecurring.push(i);
+          }
         }
       } catch (err) {
         log.warn({ cron: job.cron, err: err instanceof Error ? err.message : err }, "Invalid cron expression");


### PR DESCRIPTION
## Summary
- Fixes timezone bug where non-recurring cron jobs were discarded as stale when their `prev()` returned last year's occurrence
- Root cause: when the system timezone is behind the cron's intended timezone, `prev()` for `0 8 16 3 *` returns 2025-03-16 instead of today because 08:00 local hasn't passed yet
- Now checks `next()` before discarding — if the next occurrence is within a week, the job is kept as upcoming

## Test plan
- [x] New test: upcoming non-recurring job (3 hours from now) is kept, not discarded
- [x] Existing test: truly stale job (10 days old, next is ~1 year away) is still discarded
- [x] Existing test: missed by 6 days still fires
- [x] `bun run check` passes