### PR TITLE
Fix flaky tests on host with macroclaw installed

### DIFF
--- a/src/sessions.test.ts
+++ b/src/sessions.test.ts
@@ -1,13 +1,16 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { loadSessions, newSessionId, saveSessions } from "./sessions";
 
 const tmpDir = "/tmp/macroclaw-sessions-test";
 
-afterEach(() => {
+function cleanup() {
   if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
-});
+}
+
+beforeEach(cleanup);
+afterEach(cleanup);
 
 describe("loadSessions", () => {
   it("returns empty object when dir does not exist", () => {

--- a/src/system-service.test.ts
+++ b/src/system-service.test.ts
@@ -679,6 +679,9 @@ describe("status", () => {
 		});
 		mockExistsSync.mockReturnValue(false);
 		const mgr = createManager({ home: "/nonexistent" });
+		// Override isInstalled getter — on hosts where macroclaw is installed as a systemd
+		// service, existsSync("/etc/systemd/system/macroclaw.service") returns true
+		Object.defineProperty(mgr, "isInstalled", { get: () => false });
 		const s = mgr.status();
 		expect(s.installed).toBe(false);
 		expect(s.running).toBe(false);


### PR DESCRIPTION
## Summary
- **sessions.test.ts**: Add `beforeEach` cleanup so stale state from previous test runs doesn't cause failures
- **system-service.test.ts**: Stub `isInstalled` getter so the test passes on hosts where macroclaw is actually installed as a systemd service

## Test plan
- [x] `bun run check` passes