### PR TITLE
Unified session routing

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -141,12 +141,12 @@ describe("App", () => {
     expect(bot.filterHandlers.has("callback_query:data")).toBe(true);
   });
 
-  it("registers chatid, session, and bg commands", () => {
+  it("registers chatid, bg, and sessions commands", () => {
     const app = new App(makeConfig());
     const bot = app.bot as any;
     expect(bot.commandHandlers.has("chatid")).toBe(true);
-    expect(bot.commandHandlers.has("session")).toBe(true);
     expect(bot.commandHandlers.has("bg")).toBe(true);
+    expect(bot.commandHandlers.has("sessions")).toBe(true);
   });
 
   it("registers error handler", () => {
@@ -576,7 +576,7 @@ describe("App", () => {
       expect(ctx.editMessageReplyMarkup).toHaveBeenCalledWith({ reply_markup: { inline_keyboard: [[{ text: "✓ Opened", callback_data: "_noop" }]] } });
       const calls = (bot.api.sendMessage as any).mock.calls;
       const text = calls[calls.length - 1][1];
-      expect(text).toBe("Agent not found or already finished.");
+      expect(text).toBe("Session not found or already finished.");
     });
 
     it("handles peek: callback by routing to orchestrator.handlePeek", async () => {
@@ -599,7 +599,7 @@ describe("App", () => {
       expect(ctx.editMessageReplyMarkup).toHaveBeenCalledWith({ reply_markup: { inline_keyboard: [[{ text: "✓ Peeked", callback_data: "_noop" }]] } });
       const calls = (bot.api.sendMessage as any).mock.calls;
       const text = calls[calls.length - 1][1];
-      expect(text).toBe("Agent not found or already finished.");
+      expect(text).toBe("Session not found or already finished.");
     });
 
     it("handles kill: callback by routing to orchestrator.handleKill", async () => {
@@ -622,7 +622,7 @@ describe("App", () => {
       expect(ctx.editMessageReplyMarkup).toHaveBeenCalledWith({ reply_markup: { inline_keyboard: [[{ text: "✓ Killed", callback_data: "_noop" }]] } });
       const calls = (bot.api.sendMessage as any).mock.calls;
       const text = calls[calls.length - 1][1];
-      expect(text).toBe("Agent not found or already finished.");
+      expect(text).toBe("Session not found or already finished.");
     });
 
     it("ignores callback_query from unauthorized chats", async () => {
@@ -676,35 +676,9 @@ describe("App", () => {
       expect(ctx.reply).toHaveBeenCalledWith("Chat ID: `12345`", { parse_mode: "Markdown" });
     });
 
-    it("/session sends session ID via sendMessage", async () => {
-      const app = new App(makeConfig());
-      const bot = app.bot as any;
-      const handler = bot.commandHandlers.get("session")!;
-      const ctx = { chat: { id: 12345 } };
-
-      handler(ctx);
-      await new Promise((r) => setTimeout(r, 50));
-
-      const calls = (bot.api.sendMessage as any).mock.calls;
-      expect(calls.length).toBeGreaterThan(0);
-      const text = calls[calls.length - 1][1];
-      expect(text).toBe("Session: <code>test-session</code>");
-    });
-
-    it("/session is ignored for unauthorized chats", async () => {
-      const app = new App(makeConfig());
-      const bot = app.bot as any;
-      const handler = bot.commandHandlers.get("session")!;
-      const ctx = { chat: { id: 99999 } };
-
-      handler(ctx);
-      await new Promise((r) => setTimeout(r, 50));
-
-      expect((bot.api.sendMessage as any).mock.calls.length).toBe(0);
-    });
-
-    it("/bg shows no agents via sendMessage when none are running", async () => {
-      const app = new App(makeConfig());
+    it("/bg without prompt sends usage hint", async () => {
+      const config = makeConfig();
+      const app = new App(config);
       const bot = app.bot as any;
       const handler = bot.commandHandlers.get("bg")!;
       const ctx = { chat: { id: 12345 }, match: "" };
@@ -712,9 +686,9 @@ describe("App", () => {
       handler(ctx);
       await new Promise((r) => setTimeout(r, 50));
 
+      expect((config.claude as Claude & { calls: CallInfo[] }).calls).toHaveLength(0);
       const calls = (bot.api.sendMessage as any).mock.calls;
-      const text = calls[calls.length - 1][1];
-      expect(text).toBe("No background agents running.");
+      expect(calls[calls.length - 1][1]).toBe("Usage: /bg <prompt>");
     });
 
     it("/bg with prompt spawns a background agent via sendMessage", async () => {
@@ -739,37 +713,10 @@ describe("App", () => {
       expect(claude.calls).toHaveLength(1);
     });
 
-    it("/bg lists active background agents via sendMessage", async () => {
-      const claude = mockClaude((): RunningQuery<unknown> => ({
-        sessionId: `bg-${Date.now()}`,
-        startedAt: new Date(),
-        result: new Promise(() => {}),
-        kill: mock(async () => {}),
-      }));
-      const config = makeConfig({ claude });
-      const app = new App(config);
-      const bot = app.bot as any;
-      const bgHandler = bot.commandHandlers.get("bg")!;
-
-      const spawnCtx = { chat: { id: 12345 }, match: "long task" };
-      bgHandler(spawnCtx);
-      await new Promise((r) => setTimeout(r, 10));
-
-      const listCtx = { chat: { id: 12345 }, match: "" };
-      bgHandler(listCtx);
-      await new Promise((r) => setTimeout(r, 10));
-
-      const calls = (bot.api.sendMessage as any).mock.calls;
-      const lastText = calls[calls.length - 1][1];
-      expect(lastText).toContain("long-task");
-      expect(lastText).toMatch(/\d+s/);
-    });
-
-    it("shows 'none' when no session exists yet", async () => {
-      if (existsSync(tmpSettingsDir)) rmSync(tmpSettingsDir, { recursive: true });
+    it("/sessions lists running sessions via sendMessage", async () => {
       const app = new App(makeConfig());
       const bot = app.bot as any;
-      const handler = bot.commandHandlers.get("session")!;
+      const handler = bot.commandHandlers.get("sessions")!;
       const ctx = { chat: { id: 12345 } };
 
       handler(ctx);
@@ -777,8 +724,23 @@ describe("App", () => {
 
       const calls = (bot.api.sendMessage as any).mock.calls;
       const text = calls[calls.length - 1][1];
-      expect(text).toBe("Session: <code>none</code>");
+      expect(text).toBe("No running sessions.");
     });
+
+    it("/sessions is ignored for unauthorized chats", async () => {
+      const app = new App(makeConfig());
+      const bot = app.bot as any;
+      const handler = bot.commandHandlers.get("sessions")!;
+      const ctx = { chat: { id: 99999 } };
+
+      handler(ctx);
+      await new Promise((r) => setTimeout(r, 50));
+
+      // No sendMessage calls for unauthorized
+      expect((bot.api.sendMessage as any).mock.calls.length).toBe(0);
+    });
+
+
   });
 
   describe("error handler", () => {
@@ -803,8 +765,8 @@ describe("App", () => {
       app.start();
       expect(bot.api.setMyCommands).toHaveBeenCalledWith([
         { command: "chatid", description: "Show current chat ID" },
-        { command: "session", description: "Show current session ID" },
-        { command: "bg", description: "List or spawn background agents" },
+        { command: "bg", description: "Spawn a background agent" },
+        { command: "sessions", description: "List running sessions" },
       ]);
     });
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -48,8 +48,8 @@ export class App {
     scheduler.start();
     this.#bot.api.setMyCommands([
       { command: "chatid", description: "Show current chat ID" },
-      { command: "session", description: "Show current session ID" },
-      { command: "bg", description: "List or spawn background agents" },
+      { command: "bg", description: "Spawn a background agent" },
+      { command: "sessions", description: "List running sessions" },
     ]).catch((err) => log.error({ err }, "Failed to set commands"));
     this.#bot.start({
       onStart: (botInfo) => {
@@ -73,22 +73,22 @@ export class App {
       ctx.reply(`Chat ID: \`${ctx.chat.id}\``, { parse_mode: "Markdown" });
     });
 
-    this.#bot.command("session", (ctx) => {
-      if (ctx.chat.id.toString() !== this.#config.authorizedChatId) return;
-      log.debug("Command /session");
-      this.#orchestrator.handleSessionCommand();
-    });
-
     this.#bot.command("bg", (ctx) => {
       if (ctx.chat.id.toString() !== this.#config.authorizedChatId) return;
       const prompt = ctx.match?.trim();
-      if (prompt) {
-        log.debug({ prompt }, "Command /bg spawn");
-        this.#orchestrator.handleBackgroundCommand(prompt);
+      if (!prompt) {
+        log.debug("Command /bg without prompt");
+        sendResponse(this.#bot, this.#config.authorizedChatId, "Usage: /bg <prompt>");
         return;
       }
-      log.debug("Command /bg list");
-      this.#orchestrator.handleBackgroundList();
+      log.debug({ prompt }, "Command /bg spawn");
+      this.#orchestrator.handleBackgroundCommand(prompt);
+    });
+
+    this.#bot.command("sessions", (ctx) => {
+      if (ctx.chat.id.toString() !== this.#config.authorizedChatId) return;
+      log.debug("Command /sessions");
+      this.#orchestrator.handleSessions();
     });
 
     this.#bot.on("message:photo", async (ctx) => {

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -7,13 +7,14 @@ import { saveSessions } from "./sessions";
 const tmpSettingsDir = "/tmp/macroclaw-test-orchestrator-settings";
 const TEST_WORKSPACE = "/tmp/macroclaw-test-workspace";
 
-beforeEach(() => {
-  if (existsSync(tmpSettingsDir)) rmSync(tmpSettingsDir, { recursive: true });
-});
+function cleanup() {
+  try {
+    if (existsSync(tmpSettingsDir)) rmSync(tmpSettingsDir, { recursive: true });
+  } catch { /* async completion handlers may race with cleanup */ }
+}
 
-afterEach(() => {
-  if (existsSync(tmpSettingsDir)) rmSync(tmpSettingsDir, { recursive: true });
-});
+beforeEach(cleanup);
+afterEach(cleanup);
 
 interface CallInfo {
   method: "newSession" | "resumeSession" | "forkSession";
@@ -35,6 +36,17 @@ function resolvedQuery<T>(value: T, sessionId = "test-session-id"): RunningQuery
     startedAt: new Date(),
     result: Promise.resolve(queryResult(value, sessionId)),
     kill: mock(async () => {}),
+  };
+}
+
+function pendingQuery(sessionId = "pending-sid"): { query: RunningQuery<unknown>; resolve: (v: QueryResult<unknown>) => void; reject: (e: Error) => void } {
+  let resolve!: (v: QueryResult<unknown>) => void;
+  let reject!: (e: Error) => void;
+  const result = new Promise<QueryResult<unknown>>((res, rej) => { resolve = res; reject = rej; });
+  return {
+    query: { sessionId, startedAt: new Date(), result, kill: mock(async () => {}) },
+    resolve,
+    reject,
   };
 }
 
@@ -112,36 +124,6 @@ describe("Orchestrator", () => {
       await waitForProcessing();
 
       expect(claude.calls[0].prompt).toBe("[File: /tmp/photo.jpg]");
-    });
-
-    it("builds cron prompt with prefix", async () => {
-      const claude = mockClaude({ action: "send", message: "ok", actionReason: "ok" });
-      const { orch } = makeOrchestrator(claude);
-
-      orch.handleCron("daily", "check updates");
-      await waitForProcessing();
-
-      expect(claude.calls[0].prompt).toBe("[Context: cron/daily] check updates");
-    });
-
-    it("uses cron model override", async () => {
-      const claude = mockClaude({ action: "send", message: "ok", actionReason: "ok" });
-      const { orch } = makeOrchestrator(claude, { model: "sonnet" });
-
-      orch.handleCron("smart", "think", "opus");
-      await waitForProcessing();
-
-      expect(claude.calls[0].model).toBe("opus");
-    });
-
-    it("falls back to config model when cron has no model", async () => {
-      const claude = mockClaude({ action: "send", message: "ok", actionReason: "ok" });
-      const { orch } = makeOrchestrator(claude, { model: "sonnet" });
-
-      orch.handleCron("basic", "check");
-      await waitForProcessing();
-
-      expect(claude.calls[0].model).toBe("sonnet");
     });
 
     it("builds button click prompt", async () => {
@@ -226,6 +208,24 @@ describe("Orchestrator", () => {
 
       expect(responses[0].message).toContain("[JSON Error]");
     });
+
+    it("reports error when resume fails", async () => {
+      saveSessions({ mainSessionId: "old-session" }, tmpSettingsDir);
+      const claude = mockClaude((): RunningQuery<unknown> => ({
+        sessionId: "old-session",
+        startedAt: new Date(),
+        result: Promise.reject(new QueryProcessError(1, "session not found")),
+        kill: mock(async () => {}),
+      }));
+      const { orch, responses } = makeOrchestrator(claude);
+
+      orch.handleMessage("hello");
+      await waitForProcessing();
+
+      expect(claude.calls[0].method).toBe("resumeSession");
+      expect(responses[0].message).toContain("[Error]");
+      expect(responses[0].message).toContain("session not found");
+    });
   });
 
   describe("session management", () => {
@@ -251,31 +251,6 @@ describe("Orchestrator", () => {
       expect(claude.calls[0].method).toBe("newSession");
     });
 
-    it("creates new session when resume fails", async () => {
-      saveSessions({ mainSessionId: "old-session" }, tmpSettingsDir);
-      let callCount = 0;
-      const claude = mockClaude((_info: CallInfo): RunningQuery<unknown> => {
-        callCount++;
-        if (callCount === 1) {
-          return {
-            sessionId: "old-session",
-            startedAt: new Date(),
-            result: Promise.reject(new QueryProcessError(1, "session not found")),
-            kill: mock(async () => {}),
-          };
-        }
-        return resolvedQuery({ action: "send", message: "ok", actionReason: "ok" });
-      });
-      const { orch } = makeOrchestrator(claude);
-
-      orch.handleMessage("hello");
-      await waitForProcessing();
-
-      expect(callCount).toBe(2);
-      expect(claude.calls[0].method).toBe("resumeSession");
-      expect(claude.calls[1].method).toBe("newSession");
-    });
-
     it("switches to resumeSession after first success", async () => {
       const claude = mockClaude({ action: "send", message: "ok", actionReason: "ok" });
       const { orch } = makeOrchestrator(claude);
@@ -289,18 +264,6 @@ describe("Orchestrator", () => {
       expect(claude.calls[1].method).toBe("resumeSession");
     });
 
-    it("handleSessionCommand sends session via onResponse", async () => {
-      saveSessions({ mainSessionId: "test-id" }, tmpSettingsDir);
-      const claude = mockClaude({ action: "send", message: "", actionReason: "" });
-      const { orch, responses } = makeOrchestrator(claude);
-
-      orch.handleSessionCommand();
-      await waitForProcessing();
-
-      expect(responses).toHaveLength(1);
-      expect(responses[0].message).toBe("Session: <code>test-id</code>");
-    });
-
     it("background-agent forks from main session", async () => {
       saveSessions({ mainSessionId: "main-session" }, tmpSettingsDir);
       const claude = mockClaude({ action: "send", message: "ok", actionReason: "ok" });
@@ -312,7 +275,6 @@ describe("Orchestrator", () => {
       orch.handleBackgroundCommand("do work");
       await waitForProcessing();
 
-      // bg agent uses forkSession
       expect(claude.calls[1].method).toBe("forkSession");
     });
 
@@ -324,11 +286,149 @@ describe("Orchestrator", () => {
       orch.handleMessage("hello");
       await waitForProcessing();
 
-      // Next call should use the new session ID
       orch.handleMessage("follow up");
       await waitForProcessing();
 
       expect(claude.calls[1].sessionId).toBe("new-forked-session");
+    });
+  });
+
+  describe("non-blocking handler", () => {
+    it("handler returns immediately, result delivered by completion handler", async () => {
+      const { query, resolve } = pendingQuery("main-sid");
+      const claude = mockClaude(() => query);
+      const { orch, responses } = makeOrchestrator(claude);
+
+      orch.handleMessage("hello");
+      await waitForProcessing();
+
+      // Handler returned but no response yet (query still pending)
+      expect(responses).toHaveLength(0);
+
+      // Query completes — completion handler delivers
+      resolve(queryResult({ action: "send", message: "done!", actionReason: "ok" }));
+      await waitForProcessing();
+
+      expect(responses[0].message).toBe("done!");
+    });
+
+    it("second message processes while first is still running", async () => {
+      const { query: q1, resolve: resolve1 } = pendingQuery("q1-sid");
+      const { query: q2, resolve: resolve2 } = pendingQuery("q2-sid");
+
+      let callCount = 0;
+      const claude = mockClaude((): RunningQuery<unknown> => {
+        callCount++;
+        if (callCount === 1) return q1;
+        return q2;
+      });
+      // waitThreshold=0 so second message demotes immediately
+      const { orch, responses } = makeOrchestrator(claude, { waitThreshold: 0 });
+
+      orch.handleMessage("first");
+      await waitForProcessing();
+
+      // First query is running, handler returned
+      expect(callCount).toBe(1);
+
+      orch.handleMessage("second");
+      await waitForProcessing();
+
+      // Second message caused a fork+demote, second query started
+      expect(callCount).toBe(2);
+      const secondCall = claude.calls[1];
+      expect(secondCall.method).toBe("forkSession");
+      expect(secondCall.prompt).toContain("[Context: previous task");
+      expect(secondCall.prompt).toContain("moved to background]");
+      expect(secondCall.prompt).toContain("second");
+
+      // Resolve both
+      resolve2(queryResult({ action: "send", message: "second done", actionReason: "ok" }, "q2-sid"));
+      resolve1(queryResult({ action: "send", message: "first done", actionReason: "ok" }, "q1-sid"));
+      await waitForProcessing(100);
+
+      const messages = responses.map((r) => r.message);
+      expect(messages).toContain("second done");
+      // First result goes through Claude as background context (not direct)
+    });
+
+    it("waits for main to finish when within threshold, then processes next message", async () => {
+      const { query: q1, resolve: resolve1 } = pendingQuery("main-sid");
+
+      let callCount = 0;
+      const claude = mockClaude((): RunningQuery<unknown> => {
+        callCount++;
+        if (callCount === 1) return q1;
+        return resolvedQuery({ action: "send", message: "follow-up result", actionReason: "ok" });
+      });
+      const { orch, responses } = makeOrchestrator(claude);
+
+      // First message — handler returns immediately
+      orch.handleMessage("slow task");
+      await waitForProcessing();
+      expect(callCount).toBe(1);
+
+      // Second message — main is running, within threshold, handler blocks
+      orch.handleMessage("follow up");
+      await waitForProcessing(10);
+
+      // Still blocked, only 1 call
+      expect(callCount).toBe(1);
+
+      // First query finishes — completion handler delivers, then handler unblocks
+      resolve1(queryResult({ action: "send", message: "slow done", actionReason: "ok" }));
+      await waitForProcessing(100);
+
+      expect(callCount).toBe(2);
+      const messages = responses.map((r) => r.message);
+      expect(messages).toContain("slow done");
+      expect(messages).toContain("follow-up result");
+    });
+
+    it("demotes after wait timeout when main does not finish in time", async () => {
+      const { query: q1 } = pendingQuery("main-sid");
+
+      let callCount = 0;
+      const claude = mockClaude((): RunningQuery<unknown> => {
+        callCount++;
+        if (callCount === 1) return q1;
+        return resolvedQuery({ action: "send", message: "forked result", actionReason: "ok" }, "new-main");
+      });
+      // Short threshold so we don't wait long
+      const { orch, responses } = makeOrchestrator(claude, { waitThreshold: 10 });
+
+      orch.handleMessage("slow task");
+      await waitForProcessing();
+
+      orch.handleMessage("follow up");
+      await waitForProcessing(200);
+
+      expect(callCount).toBe(2);
+      const userCall = claude.calls[1];
+      expect(userCall.prompt).toContain("[Context: previous task");
+      expect(userCall.prompt).toContain("follow up");
+      expect(responses.map((r) => r.message)).toContain("forked result");
+    });
+
+    it("delivers result with error when session not in runningSessions", async () => {
+      saveSessions({ mainSessionId: "main-session" }, tmpSettingsDir);
+      const { query, resolve } = pendingQuery("main-session");
+      const claude = mockClaude(() => query);
+      const { orch, responses } = makeOrchestrator(claude);
+
+      orch.handleMessage("hello");
+      await waitForProcessing();
+
+      // Kill the session (removes from runningSessions)
+      await orch.handleKill("main-session");
+      await waitForProcessing();
+
+      // Query completes after kill — should still deliver (with error log)
+      resolve(queryResult({ action: "send", message: "late result", actionReason: "ok" }));
+      await waitForProcessing();
+
+      const messages = responses.map((r) => r.message);
+      expect(messages).toContain("late result");
     });
   });
 
@@ -353,54 +453,6 @@ describe("Orchestrator", () => {
 
       expect(claude.calls[0].prompt).toBe('[Context: button-click] User tapped "Yes"');
       expect(responses[0].message).toBe("button response");
-    });
-
-    it("handleCron queues a cron request with right params", async () => {
-      const claude = mockClaude({ action: "send", message: "cron done", actionReason: "ok" });
-      const { orch, responses } = makeOrchestrator(claude);
-
-      orch.handleCron("daily-check", "Check for updates", "haiku");
-      await waitForProcessing();
-
-      expect(claude.calls[0].prompt).toBe("[Context: cron/daily-check] Check for updates");
-      expect(claude.calls[0].model).toBe("haiku");
-      expect(responses[0].message).toBe("cron done");
-    });
-
-    it("processes requests serially (FIFO)", async () => {
-      const callOrder: number[] = [];
-      let firstResolve: () => void;
-      const firstCallDone = new Promise<void>((r) => { firstResolve = r; });
-
-      let callNum = 0;
-      const claude = mockClaude((): RunningQuery<unknown> => {
-        callNum++;
-        const n = callNum;
-        if (n === 1) {
-          return {
-            sessionId: "sid",
-            startedAt: new Date(),
-            result: firstCallDone.then(() => {
-              callOrder.push(n);
-              return queryResult({ action: "send", message: `call ${n}`, actionReason: "ok" });
-            }),
-            kill: mock(async () => {}),
-          };
-        }
-        callOrder.push(n);
-        return resolvedQuery({ action: "send", message: `call ${n}`, actionReason: "ok" });
-      });
-      const { orch } = makeOrchestrator(claude);
-
-      orch.handleMessage("first");
-      orch.handleMessage("second");
-
-      await new Promise((r) => setTimeout(r, 10));
-      firstResolve!();
-      await waitForProcessing();
-
-      expect(claude.calls).toHaveLength(2);
-      expect(callOrder).toEqual([1, 2]);
     });
 
     it("silent response: onResponse not called when action=silent", async () => {
@@ -436,130 +488,65 @@ describe("Orchestrator", () => {
       expect(messages).toContain("Starting research");
       expect(messages).toContain('Background agent "research" started.');
 
-      // Background agent result should be fed back
       await waitForProcessing(100);
       expect(callCount).toBe(3); // 1 main + 1 bg agent + 1 bg result fed back
     });
+  });
 
-    it("deferred → sends 'taking longer' via onResponse, feeds result back when resolved", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
-      let resolveCompletion: (r: QueryResult<unknown>) => void;
-      const completion = new Promise<QueryResult<unknown>>((r) => { resolveCompletion = r; });
+  describe("cron routing", () => {
+    it("cron always forks as background, never goes through queue", async () => {
+      saveSessions({ mainSessionId: "main-session" }, tmpSettingsDir);
+      const claude = mockClaude({ action: "send", message: "ok", actionReason: "ok" });
+      const { orch } = makeOrchestrator(claude);
 
-      // Mock setTimeout to fire immediately only for the timeout race, not for waitForProcessing
-      const origSetTimeout = globalThis.setTimeout;
-      const claude = mockClaude((): RunningQuery<unknown> => {
-        // Mock setTimeout right before the race happens (synchronously after this returns)
-        globalThis.setTimeout = ((fn: Function) => { fn(); return 0 as any; }) as any;
-        return {
-          sessionId: "test-session",
-          startedAt: new Date(),
-          result: completion,
-          kill: mock(async () => {}),
-        };
-      });
-      const { orch, responses } = makeOrchestrator(claude);
-
-      orch.handleMessage("slow task");
-      // Restore immediately so waitForProcessing works
-      await new Promise((r) => origSetTimeout(r, 10));
-      globalThis.setTimeout = origSetTimeout;
+      orch.handleCron("daily-check", "Check for updates", "haiku");
       await waitForProcessing();
 
-      const messages = responses.map((r) => r.message);
-      expect(messages).toContain("This is taking longer, continuing in the background.");
-
-      resolveCompletion!(queryResult({ action: "send", message: "done!", actionReason: "ok" }));
-      await waitForProcessing(100);
-
-      const allMessages = responses.map((r) => r.message);
-      expect(allMessages).toContain("done!");
+      expect(claude.calls[0].method).toBe("forkSession");
+      expect(claude.calls[0].prompt).toContain("[Context: background-agent/cron-daily-check]");
+      expect(claude.calls[0].prompt).toContain("[Context: cron/daily-check] Check for updates");
+      expect(claude.calls[0].model).toBe("haiku");
     });
 
-    it("session fork when background agent running on main session", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
-      let resolveCompletion: (r: QueryResult<unknown>) => void;
-      const completion = new Promise<QueryResult<unknown>>((r) => { resolveCompletion = r; });
+    it("cron uses config model when none specified", async () => {
+      saveSessions({ mainSessionId: "main-session" }, tmpSettingsDir);
+      const claude = mockClaude({ action: "send", message: "ok", actionReason: "ok" });
+      const { orch } = makeOrchestrator(claude, { model: "sonnet" });
 
-      const origSetTimeout = globalThis.setTimeout;
+      orch.handleCron("basic", "check");
+      await waitForProcessing();
 
+      expect(claude.calls[0].model).toBe("sonnet");
+    });
+
+    it("cron result feeds back into main session", async () => {
+      saveSessions({ mainSessionId: "main-session" }, tmpSettingsDir);
       let callCount = 0;
       const claude = mockClaude((): RunningQuery<unknown> => {
         callCount++;
-        if (callCount === 1) {
-          globalThis.setTimeout = ((fn: Function) => { fn(); return 0 as any; }) as any;
-          return {
-            sessionId: "test-session",
-            startedAt: new Date(),
-            result: completion,
-            kill: mock(async () => {}),
-          };
-        }
-        return resolvedQuery({ action: "send", message: "forked response", actionReason: "ok" });
+        return resolvedQuery({ action: "send", message: `call ${callCount}`, actionReason: "ok" });
       });
       const { orch } = makeOrchestrator(claude);
 
-      // First message gets deferred (backgrounded on test-session)
-      orch.handleMessage("slow task");
-      await new Promise((r) => origSetTimeout(r, 10));
-      globalThis.setTimeout = origSetTimeout;
-      await waitForProcessing();
+      orch.handleCron("check", "any updates?");
+      await waitForProcessing(150);
 
-      // Second message should trigger a fork (background running on test-session = main session)
-      orch.handleMessage("follow up");
-      await waitForProcessing();
-
-      expect(claude.calls[1].method).toBe("forkSession");
-
-      resolveCompletion!(queryResult({ action: "send", message: "bg done", actionReason: "ok" }));
-      await waitForProcessing(50);
-    });
-
-    it("background result with matching session: applied directly (no extra Claude call)", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
-      let resolveCompletion: (r: QueryResult<unknown>) => void;
-      const completion = new Promise<QueryResult<unknown>>((r) => { resolveCompletion = r; });
-
-      const origSetTimeout = globalThis.setTimeout;
-
-      const claude = mockClaude((): RunningQuery<unknown> => {
-        globalThis.setTimeout = ((fn: Function) => { fn(); return 0 as any; }) as any;
-        return {
-          sessionId: "test-session",
-          startedAt: new Date(),
-          result: completion,
-          kill: mock(async () => {}),
-        };
-      });
-      const { orch, responses } = makeOrchestrator(claude);
-
-      orch.handleMessage("slow");
-      await new Promise((r) => origSetTimeout(r, 10));
-      globalThis.setTimeout = origSetTimeout;
-      await waitForProcessing();
-
-      resolveCompletion!(queryResult({ action: "send", message: "direct result", actionReason: "ok" }, "test-session"));
-      await waitForProcessing(100);
-
-      const messages = responses.map((r) => r.message);
-      expect(messages).toContain("direct result");
-      // Only called once (for the initial slow request, not for the result)
-      expect(claude.calls).toHaveLength(1);
+      expect(callCount).toBe(2); // 1 cron bg + 1 bg result fed back
     });
   });
 
-  describe("handleBackgroundList", () => {
-    it("sends 'no agents' message when none running", async () => {
+  describe("handleSessions", () => {
+    it("sends 'no sessions' message when none running", async () => {
       const claude = mockClaude({ action: "send", message: "ok", actionReason: "ok" });
       const { orch, responses } = makeOrchestrator(claude);
 
-      orch.handleBackgroundList();
+      orch.handleSessions();
       await waitForProcessing();
 
-      expect(responses[0].message).toBe("No background agents running.");
+      expect(responses[0].message).toBe("No running sessions.");
     });
 
-    it("includes detail buttons and dismiss when agents are running", async () => {
+    it("includes detail buttons and dismiss when sessions are running", async () => {
       saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
       const claude = mockClaude((): RunningQuery<unknown> => ({
         sessionId: `bg-${Date.now()}`,
@@ -572,18 +559,34 @@ describe("Orchestrator", () => {
       orch.handleBackgroundCommand("long-task");
       await waitForProcessing();
 
-      orch.handleBackgroundList();
+      orch.handleSessions();
       await waitForProcessing();
 
       const listResponse = responses[responses.length - 1];
       expect(listResponse.message).toContain("long-task");
       expect(listResponse.buttons).toBeDefined();
-      expect(listResponse.buttons!.length).toBe(2); // 1 detail + dismiss
+      expect(listResponse.buttons!.length).toBe(2);
       const detailBtn = listResponse.buttons![0];
       expect(typeof detailBtn).toBe("object");
       expect((detailBtn as any).data).toMatch(/^detail:/);
       expect((detailBtn as any).text).toContain("long-task");
       expect(listResponse.buttons![1]).toEqual({ text: "Dismiss", data: "_dismiss" });
+    });
+
+    it("marks main session in listing", async () => {
+      const { query } = pendingQuery("main-sid");
+      const claude = mockClaude(() => query);
+      const { orch, responses } = makeOrchestrator(claude);
+
+      // Start a main query (non-blocking, stays in runningSessions)
+      orch.handleMessage("task");
+      await waitForProcessing();
+
+      orch.handleSessions();
+      await waitForProcessing();
+
+      const listResponse = responses[responses.length - 1];
+      expect(listResponse.message).toContain("[main]");
     });
   });
 
@@ -595,7 +598,7 @@ describe("Orchestrator", () => {
       await orch.handlePeek("nonexistent-session");
       await waitForProcessing();
 
-      expect(responses[0].message).toBe("Agent not found or already finished.");
+      expect(responses[0].message).toBe("Session not found or already finished.");
     });
 
     it("peeks at running agent and returns status", async () => {
@@ -604,7 +607,6 @@ describe("Orchestrator", () => {
       const claude = mockClaude((): RunningQuery<unknown> => {
         callCount++;
         if (callCount === 1) {
-          // bg agent — never finishes
           return {
             sessionId: "bg-sid",
             startedAt: new Date(),
@@ -612,7 +614,6 @@ describe("Orchestrator", () => {
             kill: mock(async () => {}),
           };
         }
-        // peek fork call
         return resolvedQuery("Working on it, 50% done.", "peek-session");
       });
       const { orch, responses } = makeOrchestrator(claude);
@@ -620,12 +621,11 @@ describe("Orchestrator", () => {
       orch.handleBackgroundCommand("research");
       await waitForProcessing();
 
-      // Get the internal session ID from the peek button
-      orch.handleBackgroundList();
+      orch.handleSessions();
       await waitForProcessing();
       const listResponse = responses[responses.length - 1];
       const detailBtn = listResponse.buttons![0] as { text: string; data: string };
-      const sessionId = detailBtn.data.slice(7); // strip "detail:"
+      const sessionId = detailBtn.data.slice(7);
 
       await orch.handlePeek(sessionId);
       await waitForProcessing();
@@ -660,11 +660,11 @@ describe("Orchestrator", () => {
       orch.handleBackgroundCommand("failing-peek");
       await waitForProcessing();
 
-      orch.handleBackgroundList();
+      orch.handleSessions();
       await waitForProcessing();
       const listResponse = responses[responses.length - 1];
       const detailBtn = listResponse.buttons![0] as { text: string; data: string };
-      const sessionId = detailBtn.data.slice(7); // strip "detail:"
+      const sessionId = detailBtn.data.slice(7);
 
       await orch.handlePeek(sessionId);
       await waitForProcessing();
@@ -682,10 +682,10 @@ describe("Orchestrator", () => {
       orch.handleDetail("nonexistent-session");
       await waitForProcessing();
 
-      expect(responses[0].message).toBe("Agent not found or already finished.");
+      expect(responses[0].message).toBe("Session not found or already finished.");
     });
 
-    it("shows agent details with peek/kill/dismiss buttons", async () => {
+    it("shows session details with peek/kill/dismiss buttons", async () => {
       saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
       const claude = mockClaude((): RunningQuery<unknown> => ({
         sessionId: "bg-sid",
@@ -698,7 +698,7 @@ describe("Orchestrator", () => {
       orch.handleBackgroundCommand("research pricing");
       await waitForProcessing();
 
-      orch.handleBackgroundList();
+      orch.handleSessions();
       await waitForProcessing();
       const listResponse = responses[responses.length - 1];
       const detailBtn = listResponse.buttons![0] as { text: string; data: string };
@@ -732,7 +732,7 @@ describe("Orchestrator", () => {
       orch.handleBackgroundCommand(longPrompt);
       await waitForProcessing();
 
-      orch.handleBackgroundList();
+      orch.handleSessions();
       await waitForProcessing();
       const listResponse = responses[responses.length - 1];
       const detailBtn = listResponse.buttons![0] as { text: string; data: string };
@@ -742,7 +742,6 @@ describe("Orchestrator", () => {
       await waitForProcessing();
 
       const detailResponse = responses[responses.length - 1];
-      // 300 chars + ellipsis
       expect(detailResponse.message).toContain("a".repeat(300));
       expect(detailResponse.message).toContain("…");
       expect(detailResponse.message).not.toContain("a".repeat(301));
@@ -761,7 +760,7 @@ describe("Orchestrator", () => {
       orch.handleBackgroundCommand("research");
       await waitForProcessing();
 
-      orch.handleBackgroundList();
+      orch.handleSessions();
       await waitForProcessing();
       const listResponse = responses[responses.length - 1];
       const detailBtn = listResponse.buttons![0] as { text: string; data: string };
@@ -783,10 +782,10 @@ describe("Orchestrator", () => {
       await orch.handleKill("nonexistent-session");
       await waitForProcessing();
 
-      expect(responses[0].message).toBe("Agent not found or already finished.");
+      expect(responses[0].message).toBe("Session not found or already finished.");
     });
 
-    it("kills running agent and sends confirmation", async () => {
+    it("kills running session and sends confirmation", async () => {
       saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
       const killMock = mock(async () => {});
       const claude = mockClaude((): RunningQuery<unknown> => ({
@@ -800,7 +799,7 @@ describe("Orchestrator", () => {
       orch.handleBackgroundCommand("research pricing");
       await waitForProcessing();
 
-      orch.handleBackgroundList();
+      orch.handleSessions();
       await waitForProcessing();
       const listResponse = responses[responses.length - 1];
       const detailBtn = listResponse.buttons![0] as { text: string; data: string };
@@ -814,10 +813,9 @@ describe("Orchestrator", () => {
       expect(killResponse.message).toContain("Killed");
       expect(killResponse.message).toContain("research-pricing");
 
-      // Agent should be removed from list
-      orch.handleBackgroundList();
+      orch.handleSessions();
       await waitForProcessing();
-      expect(responses[responses.length - 1].message).toBe("No background agents running.");
+      expect(responses[responses.length - 1].message).toBe("No running sessions.");
     });
 
     it("does not feed error back to queue after kill", async () => {
@@ -835,7 +833,7 @@ describe("Orchestrator", () => {
       orch.handleBackgroundCommand("task");
       await waitForProcessing();
 
-      orch.handleBackgroundList();
+      orch.handleSessions();
       await waitForProcessing();
       const listResponse = responses[responses.length - 1];
       const detailBtn = listResponse.buttons![0] as { text: string; data: string };
@@ -845,12 +843,9 @@ describe("Orchestrator", () => {
       await waitForProcessing();
       const countAfterKill = responses.length;
 
-      // Simulate the bg process rejecting after kill
       rejectBg!(new Error("process killed"));
       await waitForProcessing(100);
 
-      // No additional error responses should have been added
-      // Only the "Killed" message, no "[Error]" from the bg handler
       const newResponses = responses.slice(countAfterKill);
       expect(newResponses.every((r) => !r.message.includes("[Error]"))).toBe(true);
     });
@@ -875,23 +870,15 @@ describe("Orchestrator", () => {
     });
   });
 
-  describe("background management (spawn/adopt)", () => {
+  describe("background management", () => {
     it("spawns background agent and feeds result back to queue", async () => {
       saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
-      let resolvePromise: (r: QueryResult<unknown>) => void;
-      const bgResult = new Promise<QueryResult<unknown>>((r) => { resolvePromise = r; });
+      const { query: bgQuery, resolve: resolveBg } = pendingQuery("bg-sid");
 
       let callCount = 0;
       const claude = mockClaude((): RunningQuery<unknown> => {
         callCount++;
-        if (callCount === 1) {
-          return {
-            sessionId: "bg-sid",
-            startedAt: new Date(),
-            result: bgResult,
-            kill: mock(async () => {}),
-          };
-        }
+        if (callCount === 1) return bgQuery;
         return resolvedQuery({ action: "send", message: "bg result processed", actionReason: "ok" });
       });
       const { orch, responses } = makeOrchestrator(claude);
@@ -901,29 +888,20 @@ describe("Orchestrator", () => {
 
       expect(responses[0].message).toContain('started.');
 
-      resolvePromise!(queryResult({ action: "send", message: "done!", actionReason: "completed" }));
+      resolveBg(queryResult({ action: "send", message: "done!", actionReason: "completed" }));
       await waitForProcessing(100);
 
-      // The bg result gets fed back to the queue and processed
-      expect(callCount).toBe(2); // 1 bg agent + 1 bg result fed back
+      expect(callCount).toBe(2);
     });
 
     it("feeds error back to queue on spawn failure", async () => {
       saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
-      let rejectPromise: (e: Error) => void;
-      const bgResult = new Promise<QueryResult<unknown>>((_, r) => { rejectPromise = r; });
+      const { query: bgQuery, reject: rejectBg } = pendingQuery("bg-sid");
 
       let callCount = 0;
       const claude = mockClaude((): RunningQuery<unknown> => {
         callCount++;
-        if (callCount === 1) {
-          return {
-            sessionId: "bg-sid",
-            startedAt: new Date(),
-            result: bgResult,
-            kill: mock(async () => {}),
-          };
-        }
+        if (callCount === 1) return bgQuery;
         return resolvedQuery({ action: "send", message: "error processed", actionReason: "ok" });
       });
       const { orch, responses } = makeOrchestrator(claude);
@@ -931,74 +909,11 @@ describe("Orchestrator", () => {
       orch.handleBackgroundCommand("failing task");
       await waitForProcessing();
 
-      rejectPromise!(new Error("spawn failed"));
+      rejectBg(new Error("spawn failed"));
       await waitForProcessing(100);
 
-      // Error should be fed back and processed
       expect(callCount).toBe(2);
       expect(responses[responses.length - 1].message).toBe("error processed");
-    });
-
-    it("adopt feeds error back when deferred rejects", async () => {
-      saveSessions({ mainSessionId: "adopted-session" }, tmpSettingsDir);
-      let rejectCompletion: (err: Error) => void;
-      const completion = new Promise<QueryResult<unknown>>((_, r) => { rejectCompletion = r; });
-
-      const origSetTimeout = globalThis.setTimeout;
-
-      const claude = mockClaude((): RunningQuery<unknown> => {
-        globalThis.setTimeout = ((fn: Function) => { fn(); return 0 as any; }) as any;
-        return {
-          sessionId: "adopted-session",
-          startedAt: new Date(),
-          result: completion,
-          kill: mock(async () => {}),
-        };
-      });
-      const { orch, responses } = makeOrchestrator(claude);
-
-      orch.handleMessage("slow");
-      await new Promise((r) => origSetTimeout(r, 10));
-      globalThis.setTimeout = origSetTimeout;
-      await waitForProcessing();
-
-      rejectCompletion!(new Error("process crashed"));
-      await waitForProcessing(100);
-
-      const messages = responses.map((r) => r.message);
-      expect(messages.some((m) => m.includes("[Error]"))).toBe(true);
-    });
-
-    it("adopt feeds result back when deferred resolves", async () => {
-      saveSessions({ mainSessionId: "adopted-session" }, tmpSettingsDir);
-      let resolveCompletion: (r: QueryResult<unknown>) => void;
-      const completion = new Promise<QueryResult<unknown>>((r) => { resolveCompletion = r; });
-
-      const origSetTimeout = globalThis.setTimeout;
-
-      const claude = mockClaude((): RunningQuery<unknown> => {
-        globalThis.setTimeout = ((fn: Function) => { fn(); return 0 as any; }) as any;
-        return {
-          sessionId: "adopted-session",
-          startedAt: new Date(),
-          result: completion,
-          kill: mock(async () => {}),
-        };
-      });
-      const { orch, responses } = makeOrchestrator(claude);
-
-      orch.handleMessage("slow");
-      await new Promise((r) => origSetTimeout(r, 10));
-      globalThis.setTimeout = origSetTimeout;
-      await waitForProcessing();
-
-      expect(responses[0].message).toContain("taking longer");
-
-      resolveCompletion!(queryResult({ action: "send", message: "completed!", actionReason: "ok" }));
-      await waitForProcessing(100);
-
-      const messages = responses.map((r) => r.message);
-      expect(messages).toContain("completed!");
     });
   });
 
@@ -1013,7 +928,7 @@ describe("Orchestrator", () => {
         claude,
       });
 
-      orch.handleBackgroundList();
+      orch.handleSessions();
       await waitForProcessing();
 
       expect(failingOnResponse).toHaveBeenCalled();

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -3,19 +3,22 @@ import {
   Claude,
   QueryParseError,
   QueryProcessError,
-  type QueryResult,
   QueryValidationError,
   type RunningQuery
 } from "./claude";
 import { writeHistoryPrompt, writeHistoryResult } from "./history";
 import { createLogger } from "./logger";
-import { CRON_TIMEOUT, MAIN_TIMEOUT, SYSTEM_PROMPT } from "./prompts";
+import { SYSTEM_PROMPT } from "./prompts";
 import { Queue } from "./queue";
 import { loadSessions, saveSessions } from "./sessions";
 
 type ButtonSpec = string | { text: string; data: string };
 
 const log = createLogger("orchestrator");
+
+// --- Constants ---
+
+const WAIT_THRESHOLD = 60_000;
 
 // --- Response schema ---
 
@@ -56,20 +59,21 @@ export interface OrchestratorResponse {
 type OrchestratorRequest =
   | { type: "user"; message: string; files?: string[] }
   | { type: "cron"; name: string; prompt: string; model?: string }
-  | { type: "background-agent-result"; name: string; response: AgentOutput; sessionId?: string }
+  | { type: "background-agent-result"; name: string; response: AgentOutput }
   | { type: "button"; label: string };
 
 function escapeHtml(text: string): string {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-// --- Background tracking ---
+// --- Session tracking ---
 
-interface BackgroundInfo {
+interface SessionInfo {
   name: string;
   prompt: string;
   model?: string;
   query: RunningQuery<AgentOutput>;
+  lastMessageAt: Date;
 }
 
 export interface OrchestratorConfig {
@@ -78,19 +82,23 @@ export interface OrchestratorConfig {
   settingsDir?: string;
   onResponse: (response: OrchestratorResponse) => Promise<void>;
   claude?: Claude;
+  /** How long to wait for a running main session before demoting it (ms). Default: 60000 */
+  waitThreshold?: number;
 }
 
 export class Orchestrator {
   #config: Omit<OrchestratorConfig , 'claude'>;
   #claude: Claude;
+  #waitThreshold: number;
 
   #mainSessionId: string | undefined;
-  #backgroundAgents = new Map<string, BackgroundInfo>();
+  #runningSessions = new Map<string, SessionInfo>();
   #queue: Queue<OrchestratorRequest>;
 
   constructor(config: OrchestratorConfig) {
     this.#config = config;
     this.#claude = config.claude ?? new Claude({ workspace: config.workspace, systemPrompt: SYSTEM_PROMPT });
+    this.#waitThreshold = config.waitThreshold ?? WAIT_THRESHOLD;
     this.#queue = new Queue<OrchestratorRequest>();
     this.#queue.setHandler((request) => this.#handleRequest(request));
 
@@ -108,7 +116,9 @@ export class Orchestrator {
   }
 
   handleCron(name: string, prompt: string, model?: string): void {
-    this.#queue.push({ type: "cron", name, prompt, model });
+    const cronName = `cron-${name}`;
+    const cronPrompt = `[Context: cron/${name}] ${prompt}`;
+    this.#spawnBackground(cronName, cronPrompt, model ?? this.#config.model);
   }
 
   handleBackgroundCommand(prompt: string): void {
@@ -117,38 +127,42 @@ export class Orchestrator {
     this.#callOnResponse({ message: `Background agent "${escapeHtml(name)}" started.` });
   }
 
-  handleBackgroundList(): void {
-    const agents = [...this.#backgroundAgents.values()];
-    if (agents.length === 0) {
-      this.#callOnResponse({ message: "No background agents running." });
+  handleSessions(): void {
+    const sessions = [...this.#runningSessions.entries()];
+    if (sessions.length === 0) {
+      this.#callOnResponse({ message: "No running sessions." });
       return;
     }
-    const lines = agents.map((a) => {
-      const elapsed = Math.round((Date.now() - a.query.startedAt.getTime()) / 1000);
-      return `- ${escapeHtml(a.name)} (${elapsed}s)`;
+    const lines = sessions.map(([sid, s]) => {
+      const elapsed = Math.round((Date.now() - s.query.startedAt.getTime()) / 1000);
+      const isMain = sid === this.#mainSessionId;
+      return isMain
+        ? `▶ ${escapeHtml(s.name)} (${elapsed}s) [main]`
+        : `- ${escapeHtml(s.name)} (${elapsed}s)`;
     });
-    const buttons: ButtonSpec[] = agents.map((a) => {
-      const elapsed = Math.round((Date.now() - a.query.startedAt.getTime()) / 1000);
-      const text = `${a.name} (${elapsed}s)`.slice(0, 27);
-      return { text, data: `detail:${a.query.sessionId}` };
+    const buttons: ButtonSpec[] = sessions.map(([sid, s]) => {
+      const elapsed = Math.round((Date.now() - s.query.startedAt.getTime()) / 1000);
+      const text = `${s.name} (${elapsed}s)`.slice(0, 27);
+      return { text, data: `detail:${sid}` };
     });
-    buttons.push({text: "Dismiss", data: "_dismiss"});
+    buttons.push({ text: "Dismiss", data: "_dismiss" });
     this.#callOnResponse({ message: lines.join("\n"), buttons });
   }
 
   handleDetail(sessionId: string): void {
-    const agent = this.#backgroundAgents.get(sessionId);
-    if (!agent) {
-      this.#callOnResponse({ message: "Agent not found or already finished." });
+    const session = this.#runningSessions.get(sessionId);
+    if (!session) {
+      this.#callOnResponse({ message: "Session not found or already finished." });
       return;
     }
 
-    const elapsed = Math.round((Date.now() - agent.query.startedAt.getTime()) / 1000);
-    const truncatedPrompt = agent.prompt.length > 300 ? `${agent.prompt.slice(0, 300)}…` : agent.prompt;
+    const elapsed = Math.round((Date.now() - session.query.startedAt.getTime()) / 1000);
+    const truncatedPrompt = session.prompt.length > 300 ? `${session.prompt.slice(0, 300)}…` : session.prompt;
+    const isMain = sessionId === this.#mainSessionId;
     const lines = [
-      `<b>${escapeHtml(agent.name)}</b>`,
+      `<b>${escapeHtml(session.name)}</b>${isMain ? " [main]" : ""}`,
       `Prompt: ${escapeHtml(truncatedPrompt)}`,
-      `Model: ${agent.model ?? "default"}`,
+      `Model: ${session.model ?? "default"}`,
       `Elapsed: ${elapsed}s`,
       "Status: running",
     ];
@@ -161,16 +175,16 @@ export class Orchestrator {
   }
 
   async handlePeek(sessionId: string): Promise<void> {
-    const agent = this.#backgroundAgents.get(sessionId);
-    if (!agent) {
-      this.#callOnResponse({ message: "Agent not found or already finished." });
+    const session = this.#runningSessions.get(sessionId);
+    if (!session) {
+      this.#callOnResponse({ message: "Session not found or already finished." });
       return;
     }
 
-    this.#callOnResponse({ message: `Peeking at <b>${escapeHtml(agent.name)}</b>...` });
+    this.#callOnResponse({ message: `Peeking at <b>${escapeHtml(session.name)}</b>...` });
 
     try {
-      const startedAt = agent.query.startedAt.toISOString();
+      const startedAt = session.query.startedAt.toISOString();
       const query = this.#claude.forkSession(
         sessionId,
         `This session started at ${startedAt}. Only consider events after that time. Give a brief status update: what has been done so far, what's currently happening, and what's remaining. 2-3 sentences max.`,
@@ -178,65 +192,76 @@ export class Orchestrator {
         { model: "haiku" },
       );
       const { value } = await query.result;
-      this.#callOnResponse({ message: `<b>[${escapeHtml(agent.name)}]</b> ${value || "[No output]"}` });
+      this.#callOnResponse({ message: `<b>[${escapeHtml(session.name)}]</b> ${value || "[No output]"}` });
     } catch (err) {
-      this.#callOnResponse({ message: `Couldn't peek at ${escapeHtml(agent.name)}: ${err}` });
+      this.#callOnResponse({ message: `Couldn't peek at ${escapeHtml(session.name)}: ${err}` });
     }
   }
 
   async handleKill(sessionId: string): Promise<void> {
-    const agent = this.#backgroundAgents.get(sessionId);
-    if (!agent) {
-      this.#callOnResponse({ message: "Agent not found or already finished." });
+    const session = this.#runningSessions.get(sessionId);
+    if (!session) {
+      this.#callOnResponse({ message: "Session not found or already finished." });
       return;
     }
 
-    this.#backgroundAgents.delete(sessionId);
+    this.#runningSessions.delete(sessionId);
 
     try {
-      await agent.query.kill();
+      await session.query.kill();
     } catch (err) {
-      log.error({ err, name: agent.name }, "Kill failed");
+      log.error({ err, name: session.name }, "Kill failed");
     }
 
-    this.#callOnResponse({ message: `Killed <b>${escapeHtml(agent.name)}</b>.` });
+    this.#callOnResponse({ message: `Killed <b>${escapeHtml(session.name)}</b>.` });
   }
 
-  handleSessionCommand(): void {
-    this.#callOnResponse({ message: `Session: <code>${this.#mainSessionId ?? "none"}</code>` });
-  }
 
   // --- Internal queue handler ---
 
   async #handleRequest(request: OrchestratorRequest): Promise<void> {
     log.debug({ type: request.type }, "Incoming request");
 
-    // Background result with matching session ID: deliver directly
-    if (request.type === "background-agent-result" && request.sessionId === this.#mainSessionId) {
-      log.debug({ name: request.name }, "Background result on current session, applying directly");
-      await this.#deliverResponse(request.response);
-      return;
+    const mainInfo = this.#mainSessionId ? this.#runningSessions.get(this.#mainSessionId) : undefined;
+    let movedToBackground: string | undefined;
+
+    if (mainInfo) {
+      const elapsed = Date.now() - mainInfo.lastMessageAt.getTime();
+      if (elapsed >= this.#waitThreshold) {
+        // Main has been running too long — move to background immediately
+        log.info({ name: mainInfo.name, sessionId: mainInfo.query.sessionId }, "Moving main session to background (exceeded threshold)");
+        movedToBackground = mainInfo.prompt;
+      } else {
+        // Main started recently — wait for it to finish or threshold
+        const remaining = this.#waitThreshold - elapsed;
+        const finished = await Promise.race([
+          mainInfo.query.result.then(() => true as const, () => true as const),
+          new Promise<false>((r) => setTimeout(() => r(false), remaining)),
+        ]);
+
+        if (!finished) {
+          log.info({ name: mainInfo.name, sessionId: mainInfo.query.sessionId }, "Moving main session to background (wait timed out)");
+          movedToBackground = mainInfo.prompt;
+        }
+        // If finished: completion handler already delivered the result and removed from map.
+      }
     }
 
     await writeHistoryPrompt(request);
 
-    const result = await this.#queryWithRetry(request);
-    if (!result) return;
-
-    // Update session ID (important after fork or new session)
-    if (result.sessionId !== this.#mainSessionId) {
-      log.info({ oldSessionId: this.#mainSessionId, newSessionId: result.sessionId }, "Session updated");
-      this.#mainSessionId = result.sessionId;
-      saveSessions({ mainSessionId: this.#mainSessionId }, this.#config.settingsDir);
+    let prompt = this.#formatPrompt(request);
+    if (movedToBackground) {
+      const truncated = movedToBackground.length > 100 ? `${movedToBackground.slice(0, 100)}...` : movedToBackground;
+      prompt = `[Context: previous task "${truncated}" moved to background]\n${prompt}`;
     }
 
-    await writeHistoryResult(result.value);
-    await this.#deliverResponse(result.value);
+    this.#startMainQuery(prompt, this.#config.model);
   }
 
   // --- Response delivery ---
 
   async #deliverResponse(response: AgentOutput): Promise<void> {
+    await writeHistoryResult(response);
     if (response.action === "send") {
       this.#callOnResponse({
         message: response.message || "[No output]",
@@ -262,53 +287,59 @@ export class Orchestrator {
     });
   }
 
-  // --- Claude calls ---
+  // --- Main session query ---
 
-  async #queryWithRetry(request: OrchestratorRequest): Promise<QueryResult<AgentOutput> | null> {
-    const timeout = request.type === "cron" ? CRON_TIMEOUT : MAIN_TIMEOUT;
-    const query = this.#query(request);
-
-    try {
-      const result = await this.#awaitOrBackground(query, request, timeout);
-      if (!result) return null;
-      return result;
-    } catch (err) {
-      // Resume failed — retry with a fresh session
-      if (err instanceof QueryProcessError && this.#mainSessionId) {
-        log.info("Resume failed, retrying with new session");
-        this.#mainSessionId = undefined;
-        const retryQuery = this.#query(request);
-
-        try {
-          const retryResult = await this.#awaitOrBackground(retryQuery, request, timeout);
-          if (!retryResult) return null;
-          return retryResult;
-        } catch (retryErr) {
-          return { value: this.#errorResponse(retryErr), sessionId: retryQuery.sessionId };
-        }
-      }
-
-      return { value: this.#errorResponse(err), sessionId: this.#mainSessionId ?? "" };
-    }
-  }
-
-  #query(request: OrchestratorRequest) {
-    const prompt = this.#formatPrompt(request);
-    const model = request.type === "cron" ? (request.model ?? this.#config.model) : this.#config.model;
+  #startMainQuery(prompt: string, model: string | undefined): void {
     const opts = { model };
+    let query: RunningQuery<AgentOutput>;
 
-    // Fork if a background agent is running on the main session
-    if (this.#mainSessionId && this.#backgroundAgents.has(this.#mainSessionId)) {
-      return this.#claude.forkSession(this.#mainSessionId, prompt, responseResultType, opts);
+    if (this.#mainSessionId && this.#runningSessions.has(this.#mainSessionId)) {
+      query = this.#claude.forkSession(this.#mainSessionId, prompt, responseResultType, opts);
+    } else if (this.#mainSessionId) {
+      query = this.#claude.resumeSession(this.#mainSessionId, prompt, responseResultType, opts);
+    } else {
+      query = this.#claude.newSession(prompt, responseResultType, opts);
     }
 
-    // Resume existing session
-    if (this.#mainSessionId) {
-      return this.#claude.resumeSession(this.#mainSessionId, prompt, responseResultType, opts);
+    const sid = query.sessionId;
+    const name = prompt.slice(0, 30).replace(/\s+/g, "-");
+    this.#runningSessions.set(sid, { name, prompt, model, query, lastMessageAt: new Date() });
+
+    if (sid !== this.#mainSessionId) {
+      log.info({ oldSessionId: this.#mainSessionId, newSessionId: sid }, "Session updated");
+      this.#mainSessionId = sid;
+      saveSessions({ mainSessionId: sid }, this.#config.settingsDir);
     }
 
-    // Start fresh
-    return this.#claude.newSession(prompt, responseResultType, opts);
+    log.debug({ name, sessionId: sid }, "Main query started");
+
+    query.result.then(
+      async ({ value: response }) => {
+        if (!this.#runningSessions.has(sid)) {
+          log.error({ name, sessionId: sid }, "Completed session not in runningSessions — delivering anyway");
+          await this.#deliverResponse(response);
+          return;
+        }
+        this.#runningSessions.delete(sid);
+
+        if (sid === this.#mainSessionId) {
+          log.debug({ name, sessionId: sid }, "Main query finished, delivering directly");
+          await this.#deliverResponse(response);
+        } else {
+          log.debug({ name, sessionId: sid }, "Non-main query finished, feeding to main session");
+          this.#queue.push({ type: "background-agent-result", name, response });
+        }
+      },
+      async (err) => {
+        if (!this.#runningSessions.has(sid)) {
+          log.error({ name, sessionId: sid, err }, "Failed session not in runningSessions — delivering error");
+        } else {
+          this.#runningSessions.delete(sid);
+          log.error({ name, sessionId: sid, err }, "Main query failed");
+        }
+        await this.#deliverResponse(this.#errorResponse(err));
+      },
+    );
   }
 
   #formatPrompt(request: OrchestratorRequest): string {
@@ -325,29 +356,6 @@ export class Orchestrator {
       case "button":
         return `[Context: button-click] User tapped "${request.label}"`;
     }
-  }
-
-  async #awaitOrBackground(
-    query: RunningQuery<AgentOutput>,
-    request: OrchestratorRequest,
-    timeoutMs: number,
-  ): Promise<QueryResult<AgentOutput> | null> {
-    const result = await Promise.race([
-      query.result,
-      new Promise<null>((resolve) => setTimeout(() => resolve(null), timeoutMs)),
-    ]);
-
-    if (result !== null) return result;
-
-    const name = request.type === "user" ? request.message.slice(0, 30).replace(/\s+/g, "-")
-      : request.type === "cron" ? `cron-${request.name}`
-      : "task";
-    const prompt = this.#formatPrompt(request);
-    const model = request.type === "cron" ? (request.model ?? this.#config.model) : this.#config.model;
-    log.info({ name, sessionId: query.sessionId }, "Request backgrounded due to timeout");
-    this.#callOnResponse({ message: "This is taking longer, continuing in the background." });
-    this.#adoptBackground(name, prompt, model, query);
-    return null;
   }
 
   #errorResponse(err: unknown): AgentOutput {
@@ -372,47 +380,27 @@ export class Orchestrator {
     const query = this.#mainSessionId
       ? this.#claude.forkSession(this.#mainSessionId, bgPrompt, responseResultType, { model })
       : this.#claude.newSession(bgPrompt, responseResultType, { model });
-    const sessionId = query.sessionId;
-    const info: BackgroundInfo = { name, prompt, model, query };
-    this.#backgroundAgents.set(sessionId, info);
-
-    log.debug({ name, sessionId }, "Starting background agent");
-
-    query.result.then(
-      async ({ value: response }) => {
-        if (!this.#backgroundAgents.has(sessionId)) return;
-        this.#backgroundAgents.delete(sessionId);
-        log.debug({ name, message: response.message }, "Background agent finished");
-        this.#queue.push({ type: "background-agent-result", name, response });
-      },
-      (err) => {
-        if (!this.#backgroundAgents.has(sessionId)) return;
-        this.#backgroundAgents.delete(sessionId);
-        log.error({ name, err }, "Background agent failed");
-        this.#queue.push({ type: "background-agent-result", name, response: { action: "send", message: `[Error] ${err}`, actionReason: "bg-agent-failed" } });
-      },
-    );
+    this.#registerBackground(name, prompt, model, query);
   }
 
-  #adoptBackground(name: string, prompt: string, model: string | undefined, query: RunningQuery<AgentOutput>) {
-    const sessionId = query.sessionId;
-    const info: BackgroundInfo = { name, prompt, model, query };
-    this.#backgroundAgents.set(sessionId, info);
+  #registerBackground(name: string, prompt: string, model: string | undefined, query: RunningQuery<AgentOutput>) {
+    const sid = query.sessionId;
+    this.#runningSessions.set(sid, { name, prompt, model, query, lastMessageAt: new Date() });
 
-    log.debug({ name, sessionId }, "Adopting backgrounded task");
+    log.debug({ name, sessionId: sid }, "Background session registered");
 
     query.result.then(
       ({ value: response }) => {
-        if (!this.#backgroundAgents.has(sessionId)) return;
-        this.#backgroundAgents.delete(sessionId);
-        log.debug({ name }, "Adopted task finished");
-        this.#queue.push({ type: "background-agent-result", name, response, sessionId });
+        if (!this.#runningSessions.has(sid)) return;
+        this.#runningSessions.delete(sid);
+        log.debug({ name, message: response.message }, "Background session finished");
+        this.#queue.push({ type: "background-agent-result", name, response });
       },
       (err) => {
-        if (!this.#backgroundAgents.has(sessionId)) return;
-        this.#backgroundAgents.delete(sessionId);
-        log.error({ name, err }, "Adopted task failed");
-        this.#queue.push({ type: "background-agent-result", name, response: { action: "send", message: `[Error] ${err}`, actionReason: "deferred-failed" }, sessionId });
+        if (!this.#runningSessions.has(sid)) return;
+        this.#runningSessions.delete(sid);
+        log.error({ name, err }, "Background session failed");
+        this.#queue.push({ type: "background-agent-result", name, response: { action: "send", message: `[Error] ${err}`, actionReason: "bg-failed" } });
       },
     );
   }

--- a/src/prompts.test.ts
+++ b/src/prompts.test.ts
@@ -10,7 +10,7 @@ describe("SYSTEM_PROMPT", () => {
     expect(SYSTEM_PROMPT).toContain("Cron");
     expect(SYSTEM_PROMPT).toContain("Buttons");
     expect(SYSTEM_PROMPT).toContain("Files");
-    expect(SYSTEM_PROMPT).toContain("Timeouts");
+    expect(SYSTEM_PROMPT).toContain("Session routing");
   });
 
   it("contains HTML formatting instructions", () => {

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,12 +1,3 @@
-export const MAIN_TIMEOUT = 60_000;
-export const CRON_TIMEOUT = 300_000;
-export const BG_TIMEOUT = 1_800_000;
-
-const fmtMin = (ms: number) => {
-  const m = ms / 60_000;
-  return `${m} minute${m > 1 ? "s" : ""}`;
-};
-
 export const SYSTEM_PROMPT = `\
 AI assistant running in macroclaw, an autonomous agent platform. \
 Persistent workspace at cwd with config, memory, skills. \
@@ -28,21 +19,24 @@ Context tags: messages may be prefixed with [Context: <type>]. Types:
 - cron/<name> — automated scheduled task. Prefer action="silent" when nothing noteworthy.
 - button-click — user tapped an inline keyboard button.
 - background-result/<name> — output from a background agent you spawned. Decide whether to relay or handle silently.
-- background-agent/<name> — you are a background agent. Complete task, return result. Cannot spawn sub-agents.
+- background-agent/<name> — you are a background agent. Complete task, return result.
+- previous task "<prompt>" moved to background — a long-running task was demoted. Mention briefly if relevant.
 
 Background agents: spawn alongside any response via backgroundAgents array:
   backgroundAgents: [{ name: "label", prompt: "task", model: "haiku" }]
-Each runs in same workspace, fresh session. Result fed back as [Context: background-result/<name>].
+Each runs in same workspace, forked session. Result fed back as [Context: background-result/<name>].
 Models: haiku (fast/cheap), sonnet (balanced, default), opus (complex reasoning).
-User can spawn directly with "bg:" prefix. Use for long-running tasks that shouldn't block.
+User can spawn directly with /bg command. Use for long-running tasks that shouldn't block.
+
+Session routing: if a new message arrives while your session is busy for over 1 minute, \
+the running task is automatically moved to background and a new session is forked. \
+You may see a [Context: previous task "..." moved to background] prefix when this happens.
 
 Files: attachments listed as [File: /path] prefixes. Read/view at those paths. \
 Send files via files array (absolute paths). Images (.png/.jpg/.jpeg/.gif/.webp) as photos, rest as documents. 50MB limit.
 
-Timeouts: user=${fmtMin(MAIN_TIMEOUT)}, cron=${fmtMin(CRON_TIMEOUT)}, background=${fmtMin(BG_TIMEOUT)}. \
-On timeout, task continues in background automatically. Spawn background agents proactively for long tasks.
-
-Cron: jobs in data/schedule.json (hot-reloaded). Use "silent" when check finds nothing new, "send" when noteworthy.
+Cron: jobs in data/schedule.json (hot-reloaded). Cron jobs always run as background sessions. \
+Use "silent" when check finds nothing new, "send" when noteworthy.
 
 MessageButtons: include a buttons field (flat array of label strings) to attach inline buttons below your message. \
 Each button gets its own row. Max 27 characters per label — if options need more detail, describe them in the message and use short labels on buttons.`;


### PR DESCRIPTION
Closes #28

## Summary
- Replace timeout-based backgrounding with message-arrival routing: if main session is running > 1min when a new message arrives, fork+demote; if < 1min, queue and wait
- Cron jobs always fork as background, never block main session
- Split `/bg` (create-only) and add `/sessions` (list all running, main marked)
- Merge `#spawnBackground`/`#adoptBackground` into `#registerBackground`
- Remove `MAIN_TIMEOUT`/`CRON_TIMEOUT`/`BG_TIMEOUT`, no more premature "taking longer" notifications
- Demotion context prepended to new message: `[Context: previous task "..." moved to background]`

## Test plan
- [x] `bun run check` passes (307 tests, 100% line coverage)
- [ ] Manual test: send message, verify resume works
- [ ] Manual test: send message while previous is running > 1min, verify fork+demote
- [ ] Manual test: rapid-fire messages queue correctly
- [ ] Manual test: `/sessions` shows running sessions with main marked
- [ ] Manual test: cron job runs as background without blocking main