### PR TITLE
Fix self-update skill to use user service manager

### DIFF
--- a/workspace-template/.claude/skills/self-update/SKILL.md
+++ b/workspace-template/.claude/skills/self-update/SKILL.md
@@ -24,6 +24,6 @@ Update macroclaw to the latest version.
 
 ## Important
 
-- The `macroclaw service update` command stops the service, installs the latest version, and starts it again. Stopping the service kills all processes in the cgroup — including this Claude Code session.
+- The `macroclaw service update` command stops the user service, installs the latest version, and starts it again. Stopping the service kills all processes in the cgroup — including this Claude Code session.
 - Do NOT use a background agent — it gets killed along with the main process.
 - Always run step 4 LAST — everything after it may not execute.

--- a/workspace-template/.claude/skills/self-update/scripts/update.sh
+++ b/workspace-template/.claude/skills/self-update/scripts/update.sh
@@ -10,16 +10,15 @@ LOG_FILE="$1"
 
 case "$(uname -s)" in
   Linux)
-    sudo systemd-run \
+    systemd-run --user \
       --unit="macroclaw-update-$(date -u +%Y%m%dT%H%M%SZ)" \
       --collect \
       --no-block \
-      --property="User=$(id -un)" \
-      --property="Group=$(id -gn)" \
-      --setenv="HOME=$HOME" \
       --setenv="PATH=$PATH" \
       /bin/bash -lc "exec macroclaw service update > \"$LOG_FILE\" 2>&1"
 
+    # --user: run in user service manager (not system), so the transient unit
+    #   has access to the user D-Bus session bus and can restart user services.
     # --collect: automatically remove the transient unit after it finishes.
     # --no-block: return immediately instead of waiting for the started job.
     ;;


### PR DESCRIPTION
## Summary

- Switch `systemd-run` from `sudo` (system manager) to `--user` (user service manager) so the transient update unit can access the user D-Bus session and restart user services
- Remove now-unnecessary `--property=User/Group` and `--setenv=HOME` flags
- Update SKILL.md documentation to reflect "user service"

## Test plan

- [ ] Trigger `/self-update` skill on the remote machine and verify the update completes successfully
- [ ] Check that the transient systemd unit runs under the user service manager (`systemctl --user status`)