### PR TITLE
Suppress error on /clear of busy session

### DIFF
--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -1121,6 +1121,24 @@ describe("Orchestrator", () => {
       expect(responses.some((r) => r.message === "Session cleared.")).toBe(true);
     });
 
+    it("does not deliver error when clear kills a busy main process", async () => {
+      const { process: mainProc, reject } = pendingProcess("main-sid");
+      const claude = mockClaude(() => mainProc);
+      const { orch, responses } = makeOrchestrator(claude);
+
+      orch.handleMessage("hello");
+      await waitForProcessing();
+
+      await orch.handleClear();
+      // Simulate process exit after kill (exit code 143 = SIGTERM)
+      reject(new QueryProcessError(143, ""));
+      await waitForProcessing();
+
+      const messages = responses.map((r) => r.message);
+      expect(messages).toContain("Session cleared.");
+      expect(messages).not.toContainEqual(expect.stringContaining("[Error]"));
+    });
+
     it("creates new session (not resume) for next message after clear", async () => {
       const { process: p1, resolve: r1 } = pendingProcess("first-sid");
       let callCount = 0;

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -390,11 +390,11 @@ export class Orchestrator {
       },
       async (err) => {
         if (!this.#runningSessions.has(sid)) {
-          log.error({ name, sessionId: sid, err }, "Failed session not in runningSessions — delivering error");
-        } else {
-          this.#clearSession(sid);
-          log.error({ name, sessionId: sid, err }, "Main query failed");
+          log.debug({ name, sessionId: sid }, "Cleared session failed (expected)");
+          return;
         }
+        this.#clearSession(sid);
+        log.error({ name, sessionId: sid, err }, "Main query failed");
         await this.#deliverResponse(this.#errorResponse(err));
       },
     );


### PR DESCRIPTION
## Summary
- When `/clear` kills a busy main process, the SIGTERM rejection was delivered to the user as `[Error] Claude exited with code 143:` — now suppressed
- Matches the existing behavior in background session handlers which already silently return when the session was pre-cleared

## Test plan
- [x] New test: clear while main is busy → no error delivered, only "Session cleared."
- [x] `bun run check` passes (typecheck + lint + tests + depcheck)