### PR TITLE
Use absolute macroclaw path in generated services

### DIFF
--- a/src/system-service.test.ts
+++ b/src/system-service.test.ts
@@ -10,6 +10,7 @@ const existsSync = realExistsSync;
 const DEFAULT_LOGIN_PATH = "/usr/local/bin:/usr/bin:/bin";
 const DEFAULT_BUN_GLOBAL_BIN = "/home/testuser/.bun/bin";
 const DEFAULT_SERVICE_PATH = `${DEFAULT_BUN_GLOBAL_BIN}:${DEFAULT_LOGIN_PATH}`;
+const DEFAULT_EXECUTABLE_PATH = `${DEFAULT_BUN_GLOBAL_BIN}/macroclaw`;
 const mockExecSync = mock((cmd: string, _opts?: object): string => {
 	if (cmd === "/bin/bash -lc 'printf %s \"$PATH\"'") return `${DEFAULT_LOGIN_PATH}\n`;
 	if (cmd === "bun pm bin -g") return `${DEFAULT_BUN_GLOBAL_BIN}\n`;
@@ -236,7 +237,7 @@ describe("install", () => {
 		const plistPath = join(plistDir, "com.macroclaw.plist");
 		expect(existsSync(plistPath)).toBe(true);
 		const writtenContent = readFileSync(plistPath, "utf-8");
-		expect(writtenContent).toContain("<string>macroclaw</string>");
+		expect(writtenContent).toContain(`<string>${DEFAULT_EXECUTABLE_PATH}</string>`);
 		expect(writtenContent).toContain("<string>start</string>");
 		expect(writtenContent).toContain("<key>KeepAlive</key>");
 		expect(writtenContent).toContain(".macroclaw/logs/stdout.log");
@@ -368,7 +369,7 @@ describe("install", () => {
 		expect(unitContent).not.toContain("Environment=HOME=");
 		expect(unitContent).toContain(`Environment=PATH=${DEFAULT_SERVICE_PATH}`);
 		expect(unitContent).toContain("WorkingDirectory=%h");
-		expect(unitContent).toContain("ExecStart=macroclaw start");
+		expect(unitContent).toContain(`ExecStart=${DEFAULT_EXECUTABLE_PATH} start`);
 
 		// Lingering enabled via sudo
 		expect(mockExecSync).toHaveBeenCalledWith("sudo loginctl enable-linger testuser", expect.anything());
@@ -801,6 +802,7 @@ describe("refresh", () => {
 		expect(mockExecSync).toHaveBeenCalledWith("/bin/bash -lc 'printf %s \"$PATH\"'", expect.anything());
 		expect(mockExecSync).toHaveBeenCalledWith("bun pm bin -g", expect.anything());
 		expect(plist).toContain("<string>/home/testuser/.bun/bin:/custom/bin:/usr/bin:/bin</string>");
+		expect(plist).toContain("<string>/home/testuser/.bun/bin/macroclaw</string>");
 		expect(plist).toContain("<key>CLAUDE_CODE_OAUTH_TOKEN</key>");
 		expect(plist).toContain("<string>sk-test-token</string>");
 		rmSync(tmpHome, { recursive: true });
@@ -826,6 +828,7 @@ describe("refresh", () => {
 		expect(mockExecSync).toHaveBeenCalledWith("bun pm bin -g", expect.anything());
 		expect(mockExecSync).toHaveBeenCalledWith("systemctl --user daemon-reload", expect.anything());
 		expect(unitContent).toContain("Environment=PATH=/home/testuser/.bun/bin:/custom/bin:/usr/bin:/bin");
+		expect(unitContent).toContain("ExecStart=/home/testuser/.bun/bin/macroclaw start");
 		rmSync(tmpHome, { recursive: true });
 	});
 
@@ -845,8 +848,30 @@ describe("refresh", () => {
 		mgr.refresh();
 		const unitContent = readFileSync(join(unitDir, "macroclaw.service"), "utf-8");
 
-		expect(unitContent).toContain("Environment=PATH=/usr/local/bin:/home/testuser/.bun/bin:/usr/bin:/bin");
-		expect(unitContent).not.toContain("Environment=PATH=/home/testuser/.bun/bin:/usr/local/bin:/home/testuser/.bun/bin:/usr/bin:/bin");
+		expect(unitContent).toContain("Environment=PATH=/home/testuser/.bun/bin:/usr/local/bin:/usr/bin:/bin");
+		expect(unitContent).not.toContain("Environment=PATH=/usr/local/bin:/home/testuser/.bun/bin:/usr/local/bin:/usr/bin:/bin");
+		rmSync(tmpHome, { recursive: true });
+	});
+
+	it("dedupes repeated PATH entries while keeping bun global bin first", () => {
+		const tmpHome = `/tmp/macroclaw-test-refresh-systemd-path-dedup-${Date.now()}`;
+		const unitDir = join(tmpHome, ".config/systemd/user");
+		mkdirSync(unitDir, { recursive: true });
+		writeFileSync(join(unitDir, "macroclaw.service"), "test");
+
+		mockExecSync.mockImplementation((cmd: string) => {
+			if (cmd === "/bin/bash -lc 'printf %s \"$PATH\"'") {
+				return "/home/testuser/.bun/bin:/usr/local/bin:/usr/bin:/usr/local/bin:/usr/bin:/bin:/home/testuser/.bun/bin\n";
+			}
+			if (cmd === "bun pm bin -g") return "/home/testuser/.bun/bin\n";
+			return "";
+		});
+
+		const mgr = createManager({ platform: "linux", home: tmpHome });
+		mgr.refresh();
+		const unitContent = readFileSync(join(unitDir, "macroclaw.service"), "utf-8");
+
+		expect(unitContent).toContain("Environment=PATH=/home/testuser/.bun/bin:/usr/local/bin:/usr/bin:/bin");
 		rmSync(tmpHome, { recursive: true });
 	});
 });

--- a/src/system-service.ts
+++ b/src/system-service.ts
@@ -87,6 +87,7 @@ export class SystemServiceManager {
 
 		this.#exec("bun install -g macroclaw");
 		const servicePath = this.#getServicePath();
+		const executablePath = this.#getMacroclawExecutablePath();
 
 		const logDir = resolve(this.#home, ".macroclaw/logs");
 		mkdirSync(logDir, { recursive: true });
@@ -94,7 +95,7 @@ export class SystemServiceManager {
 			this.#exec(`launchctl unload ${this.serviceFilePath}`);
 		}
 
-		writeFileSync(this.serviceFilePath, this.#generateLaunchdPlist(servicePath, oauthToken));
+		writeFileSync(this.serviceFilePath, this.#generateLaunchdPlist(servicePath, executablePath, oauthToken));
 		log.debug({ filePath: this.serviceFilePath }, "Wrote launchd plist");
 		this.#exec(`launchctl load ${this.serviceFilePath}`);
 	}
@@ -111,6 +112,7 @@ export class SystemServiceManager {
 
 		this.#exec("bun install -g macroclaw");
 		const servicePath = this.#getServicePath();
+		const executablePath = this.#getMacroclawExecutablePath();
 
 		// Enable lingering so user services run without an active login session
 		const username = osUserInfo().username;
@@ -118,7 +120,7 @@ export class SystemServiceManager {
 			this.#sudo(`loginctl enable-linger ${username}`);
 		}
 
-		const unitContent = this.#generateSystemdUnit(servicePath);
+		const unitContent = this.#generateSystemdUnit(servicePath, executablePath);
 		mkdirSync(dirname(this.serviceFilePath), { recursive: true });
 		writeFileSync(this.serviceFilePath, unitContent);
 		log.debug({ filePath: this.serviceFilePath }, "Wrote systemd unit");
@@ -211,13 +213,14 @@ export class SystemServiceManager {
 	refresh(): void {
 		this.#requireInstalled();
 		const servicePath = this.#getServicePath();
+		const executablePath = this.#getMacroclawExecutablePath();
 		if (this.#platform === "systemd") {
-			writeFileSync(this.serviceFilePath, this.#generateSystemdUnit(servicePath));
+			writeFileSync(this.serviceFilePath, this.#generateSystemdUnit(servicePath, executablePath));
 			this.#exec("systemctl --user daemon-reload");
 			return;
 		}
 		const oauthToken = this.#getLaunchdOauthToken();
-		writeFileSync(this.serviceFilePath, this.#generateLaunchdPlist(servicePath, oauthToken));
+		writeFileSync(this.serviceFilePath, this.#generateLaunchdPlist(servicePath, executablePath, oauthToken));
 	}
 
 	status(): ServiceStatus {
@@ -271,9 +274,12 @@ export class SystemServiceManager {
 	#getServicePath(): string {
 		const shellPath = this.#getLoginShellPath();
 		const bunGlobalBin = this.#exec("bun pm bin -g").trim();
-		const entries = shellPath.split(":").filter(Boolean);
-		if (entries.includes(bunGlobalBin)) return shellPath;
-		return [bunGlobalBin, ...entries].join(":");
+		const entries = [bunGlobalBin, ...shellPath.split(":").filter(Boolean)];
+		return [...new Set(entries)].join(":");
+	}
+
+	#getMacroclawExecutablePath(): string {
+		return resolve(this.#exec("bun pm bin -g").trim(), "macroclaw");
 	}
 
 	#getLaunchdOauthToken(): string | undefined {
@@ -311,7 +317,7 @@ export class SystemServiceManager {
 		this.#exec(`sudo ${cmd}`);
 	}
 
-	#generateLaunchdPlist(servicePath: string, oauthToken?: string): string {
+	#generateLaunchdPlist(servicePath: string, executablePath: string, oauthToken?: string): string {
 		const logDir = resolve(this.#home, ".macroclaw/logs");
 		const envVars = [`\n\t<key>PATH</key>\n\t\t<string>${servicePath}</string>`];
 		if (oauthToken) {
@@ -326,7 +332,7 @@ export class SystemServiceManager {
 	<string>com.macroclaw</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>macroclaw</string>
+		<string>${executablePath}</string>
 		<string>start</string>
 	</array>
 	<key>KeepAlive</key>
@@ -340,7 +346,7 @@ export class SystemServiceManager {
 `;
 	}
 
-	#generateSystemdUnit(servicePath: string): string {
+	#generateSystemdUnit(servicePath: string, executablePath: string): string {
 		return `[Unit]
 Description=Macroclaw - Telegram-to-Claude-Code bridge
 After=network.target
@@ -349,7 +355,7 @@ After=network.target
 Type=simple
 WorkingDirectory=%h
 Environment=PATH=${servicePath}
-ExecStart=macroclaw start
+ExecStart=${executablePath} start
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
## Summary
- use the absolute macroclaw executable path from Bun's global bin in generated systemd and launchd service files
- keep a captured runtime PATH for child CLI tools, but dedupe entries and keep Bun's global bin first
- add test coverage for absolute service startup paths and PATH deduplication

## Why
Refreshing the systemd unit on a real server produced  because  was not reliably executable by systemd. The generated PATH also accumulated duplicate entries across refreshes.

This change makes service startup deterministic while preserving the runtime PATH needed by tools spawned from macroclaw.

## Verification
- bun run check