### PR TITLE
Rename schedule skill to schedule-event

### DIFF
--- a/src/claude.test.ts
+++ b/src/claude.test.ts
@@ -479,7 +479,7 @@ describe("Claude factory", () => {
       claude.newSession(textResult);
       const args = spawnArgs();
       expect(args).toContain("--disallowedTools");
-      expect(args).toContain("CronList,CronDelete,CronCreate,AskUserQuestion");
+      expect(args).toContain("CronList,CronDelete,CronCreate,AskUserQuestion,RemoteTrigger");
     });
 
     it("spawns with stdin: pipe, stdout: pipe, stderr: pipe", () => {

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -257,7 +257,7 @@ export class Claude {
       "--input-format", "stream-json",
       "--output-format", "stream-json",
       "--verbose",
-      "--disallowedTools", "CronList,CronDelete,CronCreate,AskUserQuestion",
+      "--disallowedTools", "CronList,CronDelete,CronCreate,AskUserQuestion,RemoteTrigger",
     ];
 
     if (mode.kind === "resume") {

--- a/workspace-template/.claude/skills/schedule-event/SKILL.md
+++ b/workspace-template/.claude/skills/schedule-event/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: schedule
+name: schedule-event
 description: "Schedule events, reminders, and recurring tasks. Use when the user wants to: set a reminder, schedule something for later, create a recurring task, set up a periodic check, automate a prompt on a schedule, or plan a one-time or repeating event at a specific time."
 ---
 

--- a/workspace-template/CLAUDE.md
+++ b/workspace-template/CLAUDE.md
@@ -63,6 +63,8 @@ Skills live in `.claude/skills/`.
 
 When creating new skills, always put them in `.claude/skills/` within this workspace.
 
+**Never use the built-in `/schedule` skill** — it manages cloud remote triggers which we don't use. Always use `/schedule-event` for scheduling.
+
 **Before using a skill**, check `TOOLS.md` for operational notes — custom instructions, overrides, workarounds, and tips that supplement the skill's own SKILL.md. Update `TOOLS.md` when you discover new issues or tricks.
 
 ## Workspace Structure — Keep It Clean!
@@ -79,7 +81,7 @@ When creating new skills, always put them in `.claude/skills/` within this works
 Structure:
 - `.claude/skills/` — local agent skills
 - `memory/` — daily logs (YYYY-MM-DD.md)
-- `data/schedule.json` — scheduled events and reminders (hot-reloaded, no restart needed) (use schedule skill to modify)
+- `data/schedule.json` — scheduled events and reminders (hot-reloaded, no restart needed) (use schedule-event skill to modify)
 
 ## Safety
 


### PR DESCRIPTION
## Summary
- Rename workspace skill `schedule` → `schedule-event` to avoid conflict with built-in `/schedule` (cloud remote triggers)
- Add `RemoteTrigger` to `--disallowedTools` in `claude.ts` to fully hide the built-in tool from context
- Add warning in workspace CLAUDE.md to never use the built-in `/schedule` skill

Closes #78