### PR TITLE
Multi-chat support: one Orchestrator per authorized chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,9 @@
 
 # Telegram bot token from @BotFather
 TELEGRAM_BOT_TOKEN=<from @BotFather>
-# Numeric chat ID authorized to use the bot
-AUTHORIZED_CHAT_ID=<numeric chat ID>
+# Numeric chat ID of the admin chat (can authorize additional chats at runtime via /chats-add)
+# AUTHORIZED_CHAT_ID is still honored as a legacy fallback.
+ADMIN_CHAT_ID=<numeric chat ID>
 # Claude model to use (haiku, sonnet, opus)
 MODEL=sonnet
 # Path to the agent workspace directory

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,9 @@ Two layers with unidirectional dependency: App → Orchestrator. App knows nothi
 
 ```
 App (app.ts)                        — I/O layer: Telegram + Cron
+├── AuthorizedChats (authorized-chats.ts) — runtime-mutable chat authorization list
 ├── Scheduler (scheduler.ts)        — reads data/schedule.json, fires onJob callback
-└── Orchestrator (orchestrator.ts)  — processing layer: Claude, queue, sessions, background
+└── Orchestrator × N (orchestrator.ts) — one per chat; processing layer: Claude, queue, sessions, background
     ├── Queue (queue.ts)            — serial FIFO processing (internal)
     ├── PromptBuilder (prompt-builder.ts) — builds context prefix for Claude prompts
     └── Claude (claude.ts)          — persistent `claude` process, stream-json protocol
@@ -55,9 +56,11 @@ App (app.ts)                        — I/O layer: Telegram + Cron
 ### App (I/O Layer)
 
 - Receives Telegram messages, commands, buttons, file uploads
+- Maintains one `Orchestrator` per authorized chat (keyed by chatId); incoming messages are dispatched by chatId
+- Admin chat gets a permanent orchestrator; additional chats are managed at runtime via `/chats-add` / `/chats-remove`
 - Routes to `orchestrator.handleMessage/handleButton/handleCron/handleBackgroundCommand/handleSessions/handleClear`
 - Delivers `OrchestratorResponse` to Telegram via `onResponse` callback (files, text, buttons)
-- Owns Scheduler, wires its `onJob` to `orchestrator.handleCron`
+- Owns Scheduler, routes cron jobs by the job's `chat` field (`undefined` → admin, `"*"` → all chats)
 - Only module that imports Grammy/Telegram
 
 ### Orchestrator (Processing Layer)
@@ -79,8 +82,8 @@ App (app.ts)                        — I/O layer: Telegram + Cron
 
 - Keep everything lean — this is a personal project
 - No database, no containers, no agent SDK
-- Single authorized chat only
-- Messages are processed serially (FIFO queue)
+- One Orchestrator per chat; admin chat is always present, additional chats managed at runtime
+- Messages are processed serially per-chat (each Orchestrator has its own FIFO queue)
 - When adding a new environment variable, document it in `.env.example` with a one-line comment
 - Use camelCase for acronyms in identifiers: `runCli`, `parseUrl`, `httpApi` (not `runCLI`, `parseURL`, `httpAPI`)
 - Module mocks for native/3rd-party modules: Use `mock.module("node:child_process", ...)` or `mock.module("grammy", ...)` instead of injecting wrapper params. Define the mock as a `mock()` at the top of the test file so individual tests can swap behavior via `mockImplementation`. Must be called before `await import()` of the module under test. Beware that `mock.module` is global and leaks across test files — only mock modules that other tests don't depend on (e.g. `node:child_process`, `node:os`). For widely-used modules like `node:fs`, prefer real filesystem with temp dirs, or restore the original module in `afterAll` via `mock.module("node:fs", () => realFs); mock.restore()`.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ A lightweight bridge that turns a Telegram chat into a personal AI assistant —
 
 Macroclaw runs with `dangerouslySkipPermissions` enabled. This is intentional — the bot
 is designed to run in an isolated environment (container or VM) where the workspace is
-the entire world. The single authorized chat ID ensures only one user can interact with
-the bot. See [Docker](#docker) for the recommended containerized setup.
+the entire world. Access is gated by an allowlist of authorized chat IDs: an **admin
+chat** configured at setup, plus any additional chats the admin authorizes at runtime
+via `/chatsadd`. Every other chat is silently ignored. See [Docker](#docker) for the
+recommended containerized setup.
 
 ## Requirements
 
@@ -37,16 +39,18 @@ On subsequent runs, settings are pre-filled from the file.
 
 Settings are stored in `~/.macroclaw/settings.json` and validated on startup.
 
-| Setting        | Env var override       | Default                    | Required |
-|----------------|------------------------|----------------------------|----------|
-| `botToken`     | `TELEGRAM_BOT_TOKEN`   | —                          | Yes      |
-| `chatId`       | `AUTHORIZED_CHAT_ID`   | —                          | Yes      |
-| `model`        | `MODEL`                | `sonnet`                   | No       |
-| `workspace`    | `WORKSPACE`            | `~/.macroclaw-workspace`   | No       |
-| `timeZone`     | `TIMEZONE`             | `UTC`                      | No       |
-| `openaiApiKey` | `OPENAI_API_KEY`       | —                          | No       |
-| `logLevel`     | `LOG_LEVEL`            | `info`                     | No       |
-| `pinoramaUrl`  | `PINORAMA_URL`         | —                          | No       |
+| Setting         | Env var override       | Default                    | Required |
+|-----------------|------------------------|----------------------------|----------|
+| `botToken`      | `TELEGRAM_BOT_TOKEN`   | —                          | Yes      |
+| `adminChatId`   | `ADMIN_CHAT_ID`        | —                          | Yes      |
+| `model`         | `MODEL`                | `sonnet`                   | No       |
+| `workspace`     | `WORKSPACE`            | `~/.macroclaw-workspace`   | No       |
+| `timeZone`      | `TIMEZONE`             | `UTC`                      | No       |
+| `openaiApiKey`  | `OPENAI_API_KEY`       | —                          | No       |
+| `logLevel`      | `LOG_LEVEL`            | `info`                     | No       |
+| `pinoramaUrl`   | `PINORAMA_URL`         | —                          | No       |
+
+`AUTHORIZED_CHAT_ID` is still accepted as a legacy alias for `ADMIN_CHAT_ID`.
 
 **`timeZone`** sets the agent's local time zone (IANA format, e.g. `Europe/Prague`, `America/New_York`). Used for the agent's clock display and scheduled event timing.
 
@@ -54,7 +58,36 @@ Settings are stored in `~/.macroclaw/settings.json` and validated on startup.
 
 Env vars take precedence over settings file values. On startup, a masked settings summary is printed showing which values were overridden by env vars.
 
-Session state (Claude session IDs) is stored separately in `~/.macroclaw/sessions.json`.
+Session state (Claude session IDs) is stored separately in `~/.macroclaw/sessions.json`, keyed by chat name. Runtime-authorized chats are persisted in `~/.macroclaw/authorized-chats.json`.
+
+### Multi-chat
+
+One admin chat is configured at setup and is always authorized. To authorize additional chats at runtime, send these commands from the admin chat:
+
+| Command | Description |
+|---------|-------------|
+| `/chats` | List authorized chats |
+| `/chatsadd <chatId> <name>` | Authorize a new chat. `name` is a lowercase-kebab-case label (e.g. `family`, `work`) used in cron routing and session storage. |
+| `/chatsremove <name>` | Revoke authorization and clear the chat's session |
+| `/chatsremove` (no arg) | Admin: show a button picker. Non-admin authorized chats: self-removal. |
+
+Each authorized chat has its own independent Claude session — memory, context, and tone stay isolated per chat. The agent knows which chat it's responding to via a `chat="<name>"` attribute on every event.
+
+### Group chats and Telegram Privacy Mode
+
+By default, Telegram puts bots in **Privacy Mode** when they're added to groups, which means the bot only receives:
+
+- Messages that start with `/` (commands)
+- Messages that @mention the bot
+- Replies to the bot's own messages
+
+Plain text in the group is filtered out by Telegram before it reaches the bot, so the bot appears silent. To let the bot see every message in a group:
+
+1. Message [@BotFather](https://t.me/BotFather)
+2. `/mybots` → select your bot → **Bot Settings** → **Group Privacy** → **Turn off**
+3. Kick the bot from the group and re-add it — the privacy change only applies to fresh group memberships
+
+Private (1:1) chats are unaffected.
 
 ## Commands
 

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -130,7 +130,7 @@ function sentPrompts(claude: { processes: ClaudeProcess<unknown>[] }): string[] 
 function makeConfig(overrides?: Partial<AppConfig>): AppConfig {
   return {
     botToken: "test-token",
-    authorizedChatId: "12345",
+    adminChatId: "12345",
     workspace: "/tmp/macroclaw-test-workspace",
     model: "sonnet",
     timeZone: "UTC",

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -918,6 +918,18 @@ describe("App", () => {
         expect(calls[calls.length - 1][1]).toContain("Error:");
       });
 
+      it("rejects chatId that matches the admin chat", async () => {
+        const app = makeApp();
+        const bot = app.bot as any;
+        const handler = bot.commandHandlers.get("chatsadd")!;
+
+        handler({ chat: { id: 12345 }, match: "12345 family" });
+        await new Promise((r) => setTimeout(r, 50));
+
+        const calls = (bot.api.sendMessage as any).mock.calls;
+        expect(calls[calls.length - 1][1]).toContain("already the admin chat");
+      });
+
       it("is ignored for non-admin chats", async () => {
         const app = makeApp();
         const bot = app.bot as any;

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { existsSync, rmSync } from "node:fs";
 import { App, type AppConfig } from "./app";
+import { AuthorizedChats } from "./authorized-chats";
 import { type Claude, type ClaudeProcess, type ProcessState, QueryProcessError, type QueryResult } from "./claude";
-import { saveSessions } from "./sessions";
+import { loadSessions, saveSessions } from "./sessions";
 import type { SpeechToText } from "./speech-to-text";
 
 const mockTranscribe = mock(async (_filePath: string) => "transcribed text");
@@ -169,13 +170,16 @@ describe("App", () => {
     expect(bot.filterHandlers.has("callback_query:data")).toBe(true);
   });
 
-  it("registers chatid, bg, sessions, and clear commands", () => {
+  it("registers chatid, bg, sessions, clear, and chats commands", () => {
     const app = makeApp();
     const bot = app.bot as any;
     expect(bot.commandHandlers.has("chatid")).toBe(true);
     expect(bot.commandHandlers.has("bg")).toBe(true);
     expect(bot.commandHandlers.has("sessions")).toBe(true);
     expect(bot.commandHandlers.has("clear")).toBe(true);
+    expect(bot.commandHandlers.has("chats")).toBe(true);
+    expect(bot.commandHandlers.has("chats-add")).toBe(true);
+    expect(bot.commandHandlers.has("chats-remove")).toBe(true);
   });
 
   it("registers error handler", () => {
@@ -793,11 +797,199 @@ describe("App", () => {
       handler(ctx);
       await new Promise((r) => setTimeout(r, 50));
 
-      // No sendMessage calls for unauthorized
       expect((bot.api.sendMessage as any).mock.calls.length).toBe(0);
     });
 
+    describe("/chats", () => {
+      it("lists authorized chats for admin", async () => {
+        const authorizedChats = new AuthorizedChats(tmpSettingsDir);
+        authorizedChats.add("55555", "family");
+        const app = makeApp({ authorizedChats });
+        const bot = app.bot as any;
+        const handler = bot.commandHandlers.get("chats")!;
 
+        handler({ chat: { id: 12345 } });
+        await new Promise((r) => setTimeout(r, 50));
+
+        const calls = (bot.api.sendMessage as any).mock.calls;
+        const text = calls[calls.length - 1][1];
+        expect(text).toContain("family");
+        expect(text).toContain("55555");
+      });
+
+      it("reports no chats when list is empty", async () => {
+        const app = makeApp();
+        const bot = app.bot as any;
+        const handler = bot.commandHandlers.get("chats")!;
+
+        handler({ chat: { id: 12345 } });
+        await new Promise((r) => setTimeout(r, 50));
+
+        const calls = (bot.api.sendMessage as any).mock.calls;
+        expect(calls[calls.length - 1][1]).toBe("No authorized chats.");
+      });
+
+      it("is ignored for non-admin chats", async () => {
+        const app = makeApp();
+        const bot = app.bot as any;
+        const handler = bot.commandHandlers.get("chats")!;
+
+        handler({ chat: { id: 99999 } });
+        await new Promise((r) => setTimeout(r, 50));
+
+        expect((bot.api.sendMessage as any).mock.calls.length).toBe(0);
+      });
+    });
+
+    describe("/chats-add", () => {
+      it("adds chat and creates orchestrator for it", async () => {
+        const app = makeApp();
+        const bot = app.bot as any;
+        const handler = bot.commandHandlers.get("chats-add")!;
+
+        handler({ chat: { id: 12345 }, match: "55555 family" });
+        await new Promise((r) => setTimeout(r, 50));
+
+        const calls = (bot.api.sendMessage as any).mock.calls;
+        expect(calls[calls.length - 1][1]).toBe('Chat "family" (55555) authorized.');
+      });
+
+      it("sends usage hint when args are missing", async () => {
+        const app = makeApp();
+        const bot = app.bot as any;
+        const handler = bot.commandHandlers.get("chats-add")!;
+
+        handler({ chat: { id: 12345 }, match: "55555" });
+        await new Promise((r) => setTimeout(r, 50));
+
+        const calls = (bot.api.sendMessage as any).mock.calls;
+        expect(calls[calls.length - 1][1]).toContain("Usage:");
+      });
+
+      it("sends usage hint when match is empty", async () => {
+        const app = makeApp();
+        const bot = app.bot as any;
+        const handler = bot.commandHandlers.get("chats-add")!;
+
+        handler({ chat: { id: 12345 }, match: "" });
+        await new Promise((r) => setTimeout(r, 50));
+
+        const calls = (bot.api.sendMessage as any).mock.calls;
+        expect(calls[calls.length - 1][1]).toContain("Usage:");
+      });
+
+      it("sends error for invalid chat name", async () => {
+        const app = makeApp();
+        const bot = app.bot as any;
+        const handler = bot.commandHandlers.get("chats-add")!;
+
+        handler({ chat: { id: 12345 }, match: "55555 InvalidName" });
+        await new Promise((r) => setTimeout(r, 50));
+
+        const calls = (bot.api.sendMessage as any).mock.calls;
+        expect(calls[calls.length - 1][1]).toContain("Error:");
+      });
+
+      it("sends error for duplicate chat", async () => {
+        const authorizedChats = new AuthorizedChats(tmpSettingsDir);
+        authorizedChats.add("55555", "family");
+        const app = makeApp({ authorizedChats });
+        const bot = app.bot as any;
+        const handler = bot.commandHandlers.get("chats-add")!;
+
+        handler({ chat: { id: 12345 }, match: "55555 family" });
+        await new Promise((r) => setTimeout(r, 50));
+
+        const calls = (bot.api.sendMessage as any).mock.calls;
+        expect(calls[calls.length - 1][1]).toContain("Error:");
+      });
+
+      it("is ignored for non-admin chats", async () => {
+        const app = makeApp();
+        const bot = app.bot as any;
+        const handler = bot.commandHandlers.get("chats-add")!;
+
+        handler({ chat: { id: 99999 }, match: "55555 family" });
+        await new Promise((r) => setTimeout(r, 50));
+
+        expect((bot.api.sendMessage as any).mock.calls.length).toBe(0);
+      });
+
+      it("newly added chat can send messages", async () => {
+        const config = makeConfig();
+        const app = trackApp(new App(config));
+        const bot = app.bot as any;
+
+        const addHandler = bot.commandHandlers.get("chats-add")!;
+        addHandler({ chat: { id: 12345 }, match: "55555 family" });
+        await new Promise((r) => setTimeout(r, 50));
+
+        const claude = config.claude as Claude & { calls: CallInfo[]; processes: ClaudeProcess<unknown>[] };
+        const callsBefore = claude.calls.length;
+
+        const textHandler = bot.filterHandlers.get("message:text")![0];
+        textHandler({ chat: { id: 55555 }, message: { text: "hello from family" } });
+        await new Promise((r) => setTimeout(r, 50));
+
+        expect(claude.calls.length).toBeGreaterThan(callsBefore);
+      });
+    });
+
+    describe("/chats-remove", () => {
+      it("removes chat and clears its session", async () => {
+        saveSessions({ mainSessions: { admin: "admin-sid", family: "fam-sid" } }, tmpSettingsDir);
+        const authorizedChats = new AuthorizedChats(tmpSettingsDir);
+        authorizedChats.add("55555", "family");
+        const app = makeApp({ authorizedChats });
+        const bot = app.bot as any;
+        const handler = bot.commandHandlers.get("chats-remove")!;
+
+        await handler({ chat: { id: 12345 }, match: "family" });
+        await new Promise((r) => setTimeout(r, 50));
+
+        const calls = (bot.api.sendMessage as any).mock.calls;
+        expect(calls[calls.length - 1][1]).toBe('Chat "family" removed.');
+
+        const sessions = loadSessions(tmpSettingsDir);
+        expect(sessions.mainSessions.family).toBeUndefined();
+        expect(sessions.mainSessions.admin).toBe("admin-sid");
+      });
+
+      it("sends usage hint when name is missing", async () => {
+        const app = makeApp();
+        const bot = app.bot as any;
+        const handler = bot.commandHandlers.get("chats-remove")!;
+
+        await handler({ chat: { id: 12345 }, match: "" });
+        await new Promise((r) => setTimeout(r, 50));
+
+        const calls = (bot.api.sendMessage as any).mock.calls;
+        expect(calls[calls.length - 1][1]).toContain("Usage:");
+      });
+
+      it("sends error for unknown chat name", async () => {
+        const app = makeApp();
+        const bot = app.bot as any;
+        const handler = bot.commandHandlers.get("chats-remove")!;
+
+        await handler({ chat: { id: 12345 }, match: "ghost" });
+        await new Promise((r) => setTimeout(r, 50));
+
+        const calls = (bot.api.sendMessage as any).mock.calls;
+        expect(calls[calls.length - 1][1]).toContain("Error:");
+      });
+
+      it("is ignored for non-admin chats", async () => {
+        const app = makeApp();
+        const bot = app.bot as any;
+        const handler = bot.commandHandlers.get("chats-remove")!;
+
+        await handler({ chat: { id: 99999 }, match: "family" });
+        await new Promise((r) => setTimeout(r, 50));
+
+        expect((bot.api.sendMessage as any).mock.calls.length).toBe(0);
+      });
+    });
   });
 
   describe("error handler", () => {
@@ -825,6 +1017,9 @@ describe("App", () => {
         { command: "bg", description: "Spawn a background agent" },
         { command: "sessions", description: "List running sessions" },
         { command: "clear", description: "Clear session and start fresh" },
+        { command: "chats", description: "List authorized chats (admin only)" },
+        { command: "chats_add", description: "Authorize a new chat (admin only)" },
+        { command: "chats_remove", description: "Remove an authorized chat (admin only)" },
       ]);
     });
   });

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -992,6 +992,73 @@ describe("App", () => {
     });
   });
 
+  describe("handleCron", () => {
+    it("routes cron job with no chat to admin orchestrator", async () => {
+      const config = makeConfig();
+      const app = trackApp(new App(config));
+
+      const claude = config.claude as Claude & { calls: CallInfo[] };
+      const callsBefore = claude.calls.length;
+      app.handleCron("check-in", "any news?", undefined, undefined, undefined);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(claude.calls.length).toBeGreaterThan(callsBefore);
+    });
+
+    it("routes cron job with chat:'admin' to admin orchestrator", async () => {
+      const config = makeConfig();
+      const app = trackApp(new App(config));
+
+      const claude = config.claude as Claude & { calls: CallInfo[] };
+      const callsBefore = claude.calls.length;
+      app.handleCron("check-in", "any news?", undefined, undefined, "admin");
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(claude.calls.length).toBeGreaterThan(callsBefore);
+    });
+
+    it("routes cron job with chat name to that chat's orchestrator", async () => {
+      const authorizedChats = new AuthorizedChats(tmpSettingsDir);
+      authorizedChats.add("55555", "family");
+      const config = makeConfig({ authorizedChats });
+      const app = trackApp(new App(config));
+
+      const claude = config.claude as Claude & { calls: CallInfo[] };
+      const callsBefore = claude.calls.length;
+      app.handleCron("family-update", "hello family", undefined, undefined, "family");
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(claude.calls.length).toBeGreaterThan(callsBefore);
+    });
+
+    it("broadcasts cron job with chat:'*' to all orchestrators", async () => {
+      const authorizedChats = new AuthorizedChats(tmpSettingsDir);
+      authorizedChats.add("55555", "family");
+      const config = makeConfig({ authorizedChats });
+      const app = trackApp(new App(config));
+
+      const claude = config.claude as Claude & { calls: CallInfo[] };
+      const callsBefore = claude.calls.length;
+      app.handleCron("broadcast", "everyone", undefined, undefined, "*");
+      await new Promise((r) => setTimeout(r, 50));
+
+      // 2 orchestrators (admin + family) → at least 2 additional claude calls
+      expect(claude.calls.length).toBeGreaterThanOrEqual(callsBefore + 2);
+    });
+
+    it("warns and does nothing for unknown chat name", async () => {
+      const config = makeConfig();
+      const app = trackApp(new App(config));
+
+      const claude = config.claude as Claude & { calls: CallInfo[] };
+      const callsBefore = claude.calls.length;
+      app.handleCron("orphan", "hello?", undefined, undefined, "nobody");
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(claude.calls.length).toBe(callsBefore);
+    });
+  });
+
   describe("error handler", () => {
     it("does not throw on bot errors", () => {
       const app = makeApp();

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -51,6 +51,20 @@ mock.module("grammy", () => ({
       opts.onStart({ username: "test_bot", id: 123 });
     }
   },
+  InlineKeyboard: class MockInlineKeyboard {
+    inline_keyboard: Array<Array<{ text: string; callback_data: string }>> = [[]];
+    text(label: string, data: string) {
+      this.inline_keyboard[this.inline_keyboard.length - 1].push({ text: label, callback_data: data });
+      return this;
+    }
+    row() {
+      this.inline_keyboard.push([]);
+      return this;
+    }
+  },
+  InputFile: class MockInputFile {
+    constructor(public path: string) {}
+  },
 }));
 
 const tmpSettingsDir = "/tmp/macroclaw-test-settings";

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -178,8 +178,8 @@ describe("App", () => {
     expect(bot.commandHandlers.has("sessions")).toBe(true);
     expect(bot.commandHandlers.has("clear")).toBe(true);
     expect(bot.commandHandlers.has("chats")).toBe(true);
-    expect(bot.commandHandlers.has("chats-add")).toBe(true);
-    expect(bot.commandHandlers.has("chats-remove")).toBe(true);
+    expect(bot.commandHandlers.has("chatsadd")).toBe(true);
+    expect(bot.commandHandlers.has("chatsremove")).toBe(true);
   });
 
   it("registers error handler", () => {
@@ -841,11 +841,11 @@ describe("App", () => {
       });
     });
 
-    describe("/chats-add", () => {
+    describe("/chatsadd", () => {
       it("adds chat and creates orchestrator for it", async () => {
         const app = makeApp();
         const bot = app.bot as any;
-        const handler = bot.commandHandlers.get("chats-add")!;
+        const handler = bot.commandHandlers.get("chatsadd")!;
 
         handler({ chat: { id: 12345 }, match: "55555 family" });
         await new Promise((r) => setTimeout(r, 50));
@@ -857,7 +857,7 @@ describe("App", () => {
       it("sends usage hint when args are missing", async () => {
         const app = makeApp();
         const bot = app.bot as any;
-        const handler = bot.commandHandlers.get("chats-add")!;
+        const handler = bot.commandHandlers.get("chatsadd")!;
 
         handler({ chat: { id: 12345 }, match: "55555" });
         await new Promise((r) => setTimeout(r, 50));
@@ -869,7 +869,7 @@ describe("App", () => {
       it("sends usage hint when match is empty", async () => {
         const app = makeApp();
         const bot = app.bot as any;
-        const handler = bot.commandHandlers.get("chats-add")!;
+        const handler = bot.commandHandlers.get("chatsadd")!;
 
         handler({ chat: { id: 12345 }, match: "" });
         await new Promise((r) => setTimeout(r, 50));
@@ -881,7 +881,7 @@ describe("App", () => {
       it("sends error for invalid chat name", async () => {
         const app = makeApp();
         const bot = app.bot as any;
-        const handler = bot.commandHandlers.get("chats-add")!;
+        const handler = bot.commandHandlers.get("chatsadd")!;
 
         handler({ chat: { id: 12345 }, match: "55555 InvalidName" });
         await new Promise((r) => setTimeout(r, 50));
@@ -895,7 +895,7 @@ describe("App", () => {
         authorizedChats.add("55555", "family");
         const app = makeApp({ authorizedChats });
         const bot = app.bot as any;
-        const handler = bot.commandHandlers.get("chats-add")!;
+        const handler = bot.commandHandlers.get("chatsadd")!;
 
         handler({ chat: { id: 12345 }, match: "55555 family" });
         await new Promise((r) => setTimeout(r, 50));
@@ -907,7 +907,7 @@ describe("App", () => {
       it("is ignored for non-admin chats", async () => {
         const app = makeApp();
         const bot = app.bot as any;
-        const handler = bot.commandHandlers.get("chats-add")!;
+        const handler = bot.commandHandlers.get("chatsadd")!;
 
         handler({ chat: { id: 99999 }, match: "55555 family" });
         await new Promise((r) => setTimeout(r, 50));
@@ -920,7 +920,7 @@ describe("App", () => {
         const app = trackApp(new App(config));
         const bot = app.bot as any;
 
-        const addHandler = bot.commandHandlers.get("chats-add")!;
+        const addHandler = bot.commandHandlers.get("chatsadd")!;
         addHandler({ chat: { id: 12345 }, match: "55555 family" });
         await new Promise((r) => setTimeout(r, 50));
 
@@ -935,14 +935,14 @@ describe("App", () => {
       });
     });
 
-    describe("/chats-remove", () => {
+    describe("/chatsremove", () => {
       it("removes chat and clears its session", async () => {
         saveSessions({ mainSessions: { admin: "admin-sid", family: "fam-sid" } }, tmpSettingsDir);
         const authorizedChats = new AuthorizedChats(tmpSettingsDir);
         authorizedChats.add("55555", "family");
         const app = makeApp({ authorizedChats });
         const bot = app.bot as any;
-        const handler = bot.commandHandlers.get("chats-remove")!;
+        const handler = bot.commandHandlers.get("chatsremove")!;
 
         await handler({ chat: { id: 12345 }, match: "family" });
         await new Promise((r) => setTimeout(r, 50));
@@ -955,22 +955,89 @@ describe("App", () => {
         expect(sessions.mainSessions.admin).toBe("admin-sid");
       });
 
-      it("sends usage hint when name is missing", async () => {
+      it("reports when no chats to remove and no arg given", async () => {
         const app = makeApp();
         const bot = app.bot as any;
-        const handler = bot.commandHandlers.get("chats-remove")!;
+        const handler = bot.commandHandlers.get("chatsremove")!;
 
         await handler({ chat: { id: 12345 }, match: "" });
         await new Promise((r) => setTimeout(r, 50));
 
         const calls = (bot.api.sendMessage as any).mock.calls;
-        expect(calls[calls.length - 1][1]).toContain("Usage:");
+        expect(calls[calls.length - 1][1]).toBe("No authorized chats to remove.");
+      });
+
+      it("sends chat-picker buttons when no arg and chats exist", async () => {
+        const authorizedChats = new AuthorizedChats(tmpSettingsDir);
+        authorizedChats.add("55555", "family");
+        authorizedChats.add("66666", "work");
+        const app = makeApp({ authorizedChats });
+        const bot = app.bot as any;
+        const handler = bot.commandHandlers.get("chatsremove")!;
+
+        await handler({ chat: { id: 12345 }, match: "" });
+        await new Promise((r) => setTimeout(r, 50));
+
+        const calls = (bot.api.sendMessage as any).mock.calls;
+        const lastCall = calls[calls.length - 1];
+        expect(lastCall[1]).toBe("Which chat to remove?");
+        const keyboard = lastCall[2].reply_markup.inline_keyboard.flat();
+        const labels = keyboard.map((b: any) => b.text);
+        expect(labels).toEqual(["family", "work", "Dismiss"]);
+        expect(keyboard.find((b: any) => b.text === "family").callback_data).toBe("chatsremove:family");
+      });
+
+      it("button callback removes the selected chat", async () => {
+        saveSessions({ mainSessions: { admin: "admin-sid", family: "fam-sid" } }, tmpSettingsDir);
+        const authorizedChats = new AuthorizedChats(tmpSettingsDir);
+        authorizedChats.add("55555", "family");
+        const app = makeApp({ authorizedChats });
+        const bot = app.bot as any;
+        const handler = bot.filterHandlers.get("callback_query:data")![0];
+
+        const ctx = {
+          chat: { id: 12345 },
+          callbackQuery: { data: "chatsremove:family" },
+          answerCallbackQuery: mock(async () => {}),
+          editMessageReplyMarkup: mock(async () => {}),
+        };
+
+        await handler(ctx);
+        await new Promise((r) => setTimeout(r, 50));
+
+        expect(ctx.editMessageReplyMarkup).toHaveBeenCalledWith({ reply_markup: { inline_keyboard: [[{ text: "✓ Removed family", callback_data: "_noop" }]] } });
+        const calls = (bot.api.sendMessage as any).mock.calls;
+        expect(calls[calls.length - 1][1]).toBe('Chat "family" removed.');
+
+        const sessions = loadSessions(tmpSettingsDir);
+        expect(sessions.mainSessions.family).toBeUndefined();
+      });
+
+      it("button callback is ignored for non-admin chats", async () => {
+        const authorizedChats = new AuthorizedChats(tmpSettingsDir);
+        authorizedChats.add("99999", "intruder");
+        const app = makeApp({ authorizedChats });
+        const bot = app.bot as any;
+        const handler = bot.filterHandlers.get("callback_query:data")![0];
+
+        const ctx = {
+          chat: { id: 99999 },
+          callbackQuery: { data: "chatsremove:intruder" },
+          answerCallbackQuery: mock(async () => {}),
+          editMessageReplyMarkup: mock(async () => {}),
+        };
+
+        await handler(ctx);
+        await new Promise((r) => setTimeout(r, 50));
+
+        // Intruder is still authorized
+        expect(authorizedChats.byName("intruder")).toBeDefined();
       });
 
       it("sends error for unknown chat name", async () => {
         const app = makeApp();
         const bot = app.bot as any;
-        const handler = bot.commandHandlers.get("chats-remove")!;
+        const handler = bot.commandHandlers.get("chatsremove")!;
 
         await handler({ chat: { id: 12345 }, match: "ghost" });
         await new Promise((r) => setTimeout(r, 50));
@@ -979,12 +1046,40 @@ describe("App", () => {
         expect(calls[calls.length - 1][1]).toContain("Error:");
       });
 
-      it("is ignored for non-admin chats", async () => {
+      it("ignores explicit-name removal from non-admin chats", async () => {
         const app = makeApp();
         const bot = app.bot as any;
-        const handler = bot.commandHandlers.get("chats-remove")!;
+        const handler = bot.commandHandlers.get("chatsremove")!;
 
         await handler({ chat: { id: 99999 }, match: "family" });
+        await new Promise((r) => setTimeout(r, 50));
+
+        expect((bot.api.sendMessage as any).mock.calls.length).toBe(0);
+      });
+
+      it("self-removes when called from non-admin chat with no arg", async () => {
+        const authorizedChats = new AuthorizedChats(tmpSettingsDir);
+        authorizedChats.add("55555", "family");
+        saveSessions({ mainSessions: { admin: "a", family: "f" } }, tmpSettingsDir);
+        const app = makeApp({ authorizedChats });
+        const bot = app.bot as any;
+        const handler = bot.commandHandlers.get("chatsremove")!;
+
+        await handler({ chat: { id: 55555 }, match: "" });
+        await new Promise((r) => setTimeout(r, 50));
+
+        const calls = (bot.api.sendMessage as any).mock.calls;
+        expect(calls[calls.length - 1][1]).toBe('Chat "family" removed.');
+        expect(authorizedChats.byName("family")).toBeUndefined();
+        expect(loadSessions(tmpSettingsDir).mainSessions.family).toBeUndefined();
+      });
+
+      it("ignores no-arg self-removal from unauthorized non-admin chat", async () => {
+        const app = makeApp();
+        const bot = app.bot as any;
+        const handler = bot.commandHandlers.get("chatsremove")!;
+
+        await handler({ chat: { id: 77777 }, match: "" });
         await new Promise((r) => setTimeout(r, 50));
 
         expect((bot.api.sendMessage as any).mock.calls.length).toBe(0);
@@ -1085,8 +1180,8 @@ describe("App", () => {
         { command: "sessions", description: "List running sessions" },
         { command: "clear", description: "Clear session and start fresh" },
         { command: "chats", description: "List authorized chats (admin only)" },
-        { command: "chats_add", description: "Authorize a new chat (admin only)" },
-        { command: "chats_remove", description: "Remove an authorized chat (admin only)" },
+        { command: "chatsadd", description: "Authorize a new chat (admin only)" },
+        { command: "chatsremove", description: "Remove an authorized chat (admin only)" },
       ]);
     });
   });

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -59,7 +59,7 @@ beforeEach(() => {
   mockTranscribe.mockReset();
   mockTranscribe.mockImplementation(async () => "transcribed text");
   if (existsSync(tmpSettingsDir)) rmSync(tmpSettingsDir, { recursive: true });
-  saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+  saveSessions({ mainSessions: { admin: "test-session" } }, tmpSettingsDir);
 });
 
 afterEach(async () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,8 +1,9 @@
 import type { Bot } from "grammy";
-import { AuthorizedChats } from "./authorized-chats";
+import { AuthorizedChats, DuplicateChatError, InvalidChatNameError, UnknownChatError } from "./authorized-chats";
 import { createLogger } from "./logger";
 import { type Claude, Orchestrator, type OrchestratorResponse } from "./orchestrator";
 import { Scheduler } from "./scheduler";
+import { clearMainSession } from "./sessions";
 import type { SpeechToText } from "./speech-to-text";
 import { createBot, downloadFile, sendFile, sendResponse } from "./telegram";
 
@@ -67,6 +68,9 @@ export class App {
       { command: "bg", description: "Spawn a background agent" },
       { command: "sessions", description: "List running sessions" },
       { command: "clear", description: "Clear session and start fresh" },
+      { command: "chats", description: "List authorized chats (admin only)" },
+      { command: "chats_add", description: "Authorize a new chat (admin only)" },
+      { command: "chats_remove", description: "Remove an authorized chat (admin only)" },
     ]).catch((err) => log.error({ err }, "Failed to set commands"));
     this.#bot.start({
       onStart: (botInfo) => {
@@ -91,6 +95,10 @@ export class App {
     });
     this.#orchestrators.set(chatId, orch);
     return orch;
+  }
+
+  #isAdminChat(chatId: number | string): boolean {
+    return chatId.toString() === this.#config.adminChatId;
   }
 
   #adminOrchestrator(): Orchestrator {
@@ -143,6 +151,71 @@ export class App {
       if (!orch) return;
       log.debug("Command /clear");
       orch.handleClear();
+    });
+
+    this.#bot.command("chats", (ctx) => {
+      if (!this.#isAdminChat(ctx.chat.id)) return;
+      log.debug("Command /chats");
+      const chatIdStr = ctx.chat.id.toString();
+      const chats = this.#authorizedChats.list();
+      if (chats.length === 0) {
+        sendResponse(this.#bot, chatIdStr, "No authorized chats.");
+        return;
+      }
+      const lines = chats.map((c) => `- ${c.name} (${c.chatId})`).join("\n");
+      sendResponse(this.#bot, chatIdStr, `Authorized chats:\n${lines}`);
+    });
+
+    this.#bot.command("chats-add", (ctx) => {
+      if (!this.#isAdminChat(ctx.chat.id)) return;
+      log.debug("Command /chats-add");
+      const chatIdStr = ctx.chat.id.toString();
+      const args = ctx.match?.trim().split(/\s+/);
+      if (!args || args.length < 2 || !args[0] || !args[1]) {
+        sendResponse(this.#bot, chatIdStr, "Usage: /chats-add &lt;chatId&gt; &lt;name&gt;");
+        return;
+      }
+      const [newChatId, name] = args;
+      try {
+        const chat = this.#authorizedChats.add(newChatId, name);
+        this.#createOrchestrator(chat.name, chat.chatId);
+        log.info({ chatId: chat.chatId, name: chat.name }, "Authorized chat added");
+        sendResponse(this.#bot, chatIdStr, `Chat "${chat.name}" (${chat.chatId}) authorized.`);
+      } catch (err) {
+        if (err instanceof DuplicateChatError || err instanceof InvalidChatNameError) {
+          sendResponse(this.#bot, chatIdStr, `Error: ${err.message}`);
+        } else {
+          throw err;
+        }
+      }
+    });
+
+    this.#bot.command("chats-remove", async (ctx) => {
+      if (!this.#isAdminChat(ctx.chat.id)) return;
+      log.debug("Command /chats-remove");
+      const chatIdStr = ctx.chat.id.toString();
+      const name = ctx.match?.trim();
+      if (!name) {
+        sendResponse(this.#bot, chatIdStr, "Usage: /chats-remove &lt;name&gt;");
+        return;
+      }
+      try {
+        const chat = this.#authorizedChats.remove(name);
+        const orch = this.#orchestrators.get(chat.chatId);
+        if (orch) {
+          await orch.dispose();
+          this.#orchestrators.delete(chat.chatId);
+        }
+        clearMainSession(name, this.#config.settingsDir);
+        log.info({ chatId: chat.chatId, name }, "Authorized chat removed");
+        sendResponse(this.#bot, chatIdStr, `Chat "${name}" removed.`);
+      } catch (err) {
+        if (err instanceof UnknownChatError) {
+          sendResponse(this.#bot, chatIdStr, `Error: ${err.message}`);
+        } else {
+          throw err;
+        }
+      }
     });
 
     this.#bot.on("message:photo", async (ctx) => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import type { Bot } from "grammy";
+import { AuthorizedChats } from "./authorized-chats";
 import { createLogger } from "./logger";
 import { type Claude, Orchestrator, type OrchestratorResponse } from "./orchestrator";
 import { Scheduler } from "./scheduler";
@@ -6,6 +7,8 @@ import type { SpeechToText } from "./speech-to-text";
 import { createBot, downloadFile, sendFile, sendResponse } from "./telegram";
 
 const log = createLogger("app");
+
+const ADMIN_CHAT_NAME = "admin";
 
 export interface AppConfig {
   botToken: string;
@@ -17,25 +20,25 @@ export interface AppConfig {
   claude?: Claude;
   stt?: SpeechToText;
   healthCheckInterval?: number;
+  /** Injected for tests. If omitted, a fresh AuthorizedChats is constructed from settingsDir. */
+  authorizedChats?: AuthorizedChats;
 }
 
 export class App {
   #bot: Bot;
-  #orchestrator: Orchestrator;
   #config: AppConfig;
+  #authorizedChats: AuthorizedChats;
+  #orchestrators = new Map<string, Orchestrator>();
 
   constructor(config: AppConfig) {
     this.#config = config;
     this.#bot = createBot(config.botToken);
-    this.#orchestrator = new Orchestrator({
-      model: config.model,
-      workspace: config.workspace,
-      timeZone: config.timeZone,
-      settingsDir: config.settingsDir,
-      claude: config.claude,
-      healthCheckInterval: config.healthCheckInterval,
-      onResponse: (r) => this.#deliverResponse(r),
-    });
+    this.#authorizedChats = config.authorizedChats ?? new AuthorizedChats(config.settingsDir);
+
+    this.#createOrchestrator(ADMIN_CHAT_NAME, config.adminChatId);
+    for (const chat of this.#authorizedChats.list()) {
+      this.#createOrchestrator(chat.name, chat.chatId);
+    }
 
     this.#setupHandlers();
   }
@@ -45,14 +48,18 @@ export class App {
   }
 
   async dispose(): Promise<void> {
-    await this.#orchestrator.dispose();
+    for (const orch of this.#orchestrators.values()) {
+      await orch.dispose();
+    }
+    this.#orchestrators.clear();
   }
 
   start() {
     log.info("Starting macroclaw...");
+    const adminOrch = this.#adminOrchestrator();
     const scheduler = new Scheduler(this.#config.workspace, {
       timeZone: this.#config.timeZone,
-      onJob: (name, prompt, model, missed) => this.#orchestrator.handleCron(name, prompt, model, missed),
+      onJob: (name, prompt, model, missed) => adminOrch.handleCron(name, prompt, model, missed),
     });
     scheduler.start();
     this.#bot.api.setMyCommands([
@@ -63,18 +70,46 @@ export class App {
     ]).catch((err) => log.error({ err }, "Failed to set commands"));
     this.#bot.start({
       onStart: (botInfo) => {
-        log.info({ username: botInfo.username, chatId: this.#config.adminChatId }, "Bot connected");
+        log.info(
+          { username: botInfo.username, adminChatId: this.#config.adminChatId, authorizedChats: this.#authorizedChats.list().length },
+          "Bot connected",
+        );
       },
     });
   }
 
-  async #deliverResponse(response: OrchestratorResponse) {
+  #createOrchestrator(chatName: string, chatId: string): Orchestrator {
+    const orch = new Orchestrator({
+      chatName,
+      model: this.#config.model,
+      workspace: this.#config.workspace,
+      timeZone: this.#config.timeZone,
+      settingsDir: this.#config.settingsDir,
+      claude: this.#config.claude,
+      healthCheckInterval: this.#config.healthCheckInterval,
+      onResponse: (r) => this.#deliverResponse(chatId, r),
+    });
+    this.#orchestrators.set(chatId, orch);
+    return orch;
+  }
+
+  #adminOrchestrator(): Orchestrator {
+    const orch = this.#orchestrators.get(this.#config.adminChatId);
+    if (!orch) throw new Error("Admin orchestrator missing — this should be impossible");
+    return orch;
+  }
+
+  #resolveOrchestrator(chatId: number | string): Orchestrator | undefined {
+    return this.#orchestrators.get(chatId.toString());
+  }
+
+  async #deliverResponse(chatId: string, response: OrchestratorResponse) {
     if (response.files?.length) {
       for (const filePath of response.files) {
-        await sendFile(this.#bot, this.#config.adminChatId, filePath);
+        await sendFile(this.#bot, chatId, filePath);
       }
     }
-    await sendResponse(this.#bot, this.#config.adminChatId, response.message, response.buttons);
+    await sendResponse(this.#bot, chatId, response.message, response.buttons);
   }
 
   #setupHandlers() {
@@ -84,73 +119,80 @@ export class App {
     });
 
     this.#bot.command("bg", (ctx) => {
-      if (ctx.chat.id.toString() !== this.#config.adminChatId) return;
+      const orch = this.#resolveOrchestrator(ctx.chat.id);
+      if (!orch) return;
       const prompt = ctx.match?.trim();
       if (!prompt) {
         log.debug("Command /bg without prompt");
-        sendResponse(this.#bot, this.#config.adminChatId, "Usage: /bg &lt;prompt&gt;");
+        sendResponse(this.#bot, ctx.chat.id.toString(), "Usage: /bg &lt;prompt&gt;");
         return;
       }
       log.debug({ prompt }, "Command /bg spawn");
-      this.#orchestrator.handleBackgroundCommand(prompt);
+      orch.handleBackgroundCommand(prompt);
     });
 
     this.#bot.command("sessions", (ctx) => {
-      if (ctx.chat.id.toString() !== this.#config.adminChatId) return;
+      const orch = this.#resolveOrchestrator(ctx.chat.id);
+      if (!orch) return;
       log.debug("Command /sessions");
-      this.#orchestrator.handleSessions();
+      orch.handleSessions();
     });
 
     this.#bot.command("clear", (ctx) => {
-      if (ctx.chat.id.toString() !== this.#config.adminChatId) return;
+      const orch = this.#resolveOrchestrator(ctx.chat.id);
+      if (!orch) return;
       log.debug("Command /clear");
-      this.#orchestrator.handleClear();
+      orch.handleClear();
     });
 
     this.#bot.on("message:photo", async (ctx) => {
-      if (ctx.chat.id.toString() !== this.#config.adminChatId) return;
+      const orch = this.#resolveOrchestrator(ctx.chat.id);
+      if (!orch) return;
       const photos = ctx.message.photo;
       const largest = photos[photos.length - 1];
       try {
         const path = await downloadFile(this.#bot, largest.file_id, this.#config.botToken, "photo.jpg");
-        this.#orchestrator.handleMessage(ctx.message.caption ?? "", [path]);
+        orch.handleMessage(ctx.message.caption ?? "", [path]);
       } catch (err) {
         log.error({ err }, "Photo download failed");
-        this.#orchestrator.handleMessage(`[File download failed: photo.jpg]\n${ctx.message.caption ?? ""}`);
+        orch.handleMessage(`[File download failed: photo.jpg]\n${ctx.message.caption ?? ""}`);
       }
     });
 
     this.#bot.on("message:document", async (ctx) => {
-      if (ctx.chat.id.toString() !== this.#config.adminChatId) return;
+      const orch = this.#resolveOrchestrator(ctx.chat.id);
+      if (!orch) return;
       const doc = ctx.message.document;
       const name = doc.file_name ?? "file";
       try {
         const path = await downloadFile(this.#bot, doc.file_id, this.#config.botToken, name);
-        this.#orchestrator.handleMessage(ctx.message.caption ?? "", [path]);
+        orch.handleMessage(ctx.message.caption ?? "", [path]);
       } catch (err) {
         log.error({ err }, "Document download failed");
-        this.#orchestrator.handleMessage(`[File download failed: ${name}]\n${ctx.message.caption ?? ""}`);
+        orch.handleMessage(`[File download failed: ${name}]\n${ctx.message.caption ?? ""}`);
       }
     });
 
     this.#bot.on("message:voice", async (ctx) => {
-      if (ctx.chat.id.toString() !== this.#config.adminChatId) return;
+      const orch = this.#resolveOrchestrator(ctx.chat.id);
+      if (!orch) return;
+      const chatIdStr = ctx.chat.id.toString();
       if (!this.#config.stt) {
-        await sendResponse(this.#bot, this.#config.adminChatId, "[Voice messages not available — set openaiApiKey in settings to enable]");
+        await sendResponse(this.#bot, chatIdStr, "[Voice messages not available — set openaiApiKey in settings to enable]");
         return;
       }
       try {
         const path = await downloadFile(this.#bot, ctx.message.voice.file_id, this.#config.botToken, "voice.ogg");
         const text = await this.#config.stt.transcribe(path);
         if (!text.trim()) {
-          await sendResponse(this.#bot, this.#config.adminChatId, "[Could not understand audio]");
+          await sendResponse(this.#bot, chatIdStr, "[Could not understand audio]");
           return;
         }
-        await sendResponse(this.#bot, this.#config.adminChatId, `[Received audio]: ${text}`);
-        this.#orchestrator.handleMessage(text);
+        await sendResponse(this.#bot, chatIdStr, `[Received audio]: ${text}`);
+        orch.handleMessage(text);
       } catch (err) {
         log.error({ err }, "Voice transcription failed");
-        await sendResponse(this.#bot, this.#config.adminChatId, "[Failed to transcribe audio]");
+        await sendResponse(this.#bot, chatIdStr, "[Failed to transcribe audio]");
       }
     });
 
@@ -158,7 +200,11 @@ export class App {
       await ctx.answerCallbackQuery();
       const data = ctx.callbackQuery.data;
       if (data === "_noop") return;
-      if (ctx.chat?.id.toString() !== this.#config.adminChatId) return;
+
+      const chatId = ctx.chat?.id;
+      if (chatId === undefined) return;
+      const orch = this.#resolveOrchestrator(chatId);
+      if (!orch) return;
 
       if (data === "_dismiss") {
         await ctx.editMessageReplyMarkup({ reply_markup: undefined });
@@ -169,7 +215,7 @@ export class App {
         const sessionId = data.slice(7);
         await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [[{ text: "✓ Opened", callback_data: "_noop" }]] } });
         log.debug({ sessionId }, "Detail requested");
-        this.#orchestrator.handleDetail(sessionId);
+        orch.handleDetail(sessionId);
         return;
       }
 
@@ -177,7 +223,7 @@ export class App {
         const sessionId = data.slice(5);
         await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [[{ text: "✓ Peeked", callback_data: "_noop" }]] } });
         log.debug({ sessionId }, "Peek requested");
-        this.#orchestrator.handlePeek(sessionId);
+        orch.handlePeek(sessionId);
         return;
       }
 
@@ -185,22 +231,23 @@ export class App {
         const sessionId = data.slice(5);
         await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [[{ text: "✓ Killed", callback_data: "_noop" }]] } });
         log.debug({ sessionId }, "Kill requested");
-        this.#orchestrator.handleKill(sessionId);
+        orch.handleKill(sessionId);
         return;
       }
 
       await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [[{ text: `✓ ${data}`, callback_data: "_noop" }]] } });
       log.debug({ label: data }, "Button clicked");
-      this.#orchestrator.handleButton(data);
+      orch.handleButton(data);
     });
 
     this.#bot.on("message:text", (ctx) => {
-      if (ctx.chat.id.toString() !== this.#config.adminChatId) {
+      const orch = this.#resolveOrchestrator(ctx.chat.id);
+      if (!orch) {
         log.debug({ chatId: ctx.chat.id }, "Unauthorized message");
         return;
       }
 
-      this.#orchestrator.handleMessage(ctx.message.text);
+      orch.handleMessage(ctx.message.text);
     });
 
     this.#bot.catch((err) => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -212,6 +212,10 @@ export class App {
         return;
       }
       const [newChatId, name] = args;
+      if (newChatId === this.#config.adminChatId) {
+        sendResponse(this.#bot, chatIdStr, "Error: chatId is already the admin chat");
+        return;
+      }
       try {
         const chat = this.#authorizedChats.add(newChatId, name);
         this.#createOrchestrator(chat.name, chat.chatId);

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,7 @@ import type { Bot } from "grammy";
 import { AuthorizedChats, DuplicateChatError, InvalidChatNameError, UnknownChatError } from "./authorized-chats";
 import { createLogger } from "./logger";
 import { type Claude, Orchestrator, type OrchestratorResponse } from "./orchestrator";
-import { Scheduler } from "./scheduler";
+import { type MissedInfo, Scheduler } from "./scheduler";
 import { clearMainSession } from "./sessions";
 import type { SpeechToText } from "./speech-to-text";
 import { createBot, downloadFile, sendFile, sendResponse } from "./telegram";
@@ -55,12 +55,27 @@ export class App {
     this.#orchestrators.clear();
   }
 
+  handleCron(name: string, prompt: string, model?: string, missed?: MissedInfo, chat?: string): void {
+    const chatName = chat ?? ADMIN_CHAT_NAME;
+    if (chatName === "*") {
+      for (const orch of this.#orchestrators.values()) {
+        orch.handleCron(name, prompt, model, missed);
+      }
+      return;
+    }
+    const orch = this.#orchestratorByName(chatName);
+    if (orch) {
+      orch.handleCron(name, prompt, model, missed);
+    } else {
+      log.warn({ chatName, jobName: name }, "Cron job targets unknown chat");
+    }
+  }
+
   start() {
     log.info("Starting macroclaw...");
-    const adminOrch = this.#adminOrchestrator();
     const scheduler = new Scheduler(this.#config.workspace, {
       timeZone: this.#config.timeZone,
-      onJob: (name, prompt, model, missed) => adminOrch.handleCron(name, prompt, model, missed),
+      onJob: (name, prompt, model, missed, chat) => this.handleCron(name, prompt, model, missed, chat),
     });
     scheduler.start();
     this.#bot.api.setMyCommands([
@@ -97,14 +112,15 @@ export class App {
     return orch;
   }
 
-  #isAdminChat(chatId: number | string): boolean {
-    return chatId.toString() === this.#config.adminChatId;
+  #orchestratorByName(chatName: string): Orchestrator | undefined {
+    if (chatName === ADMIN_CHAT_NAME) return this.#orchestrators.get(this.#config.adminChatId);
+    const chat = this.#authorizedChats.byName(chatName);
+    if (!chat) return undefined;
+    return this.#orchestrators.get(chat.chatId);
   }
 
-  #adminOrchestrator(): Orchestrator {
-    const orch = this.#orchestrators.get(this.#config.adminChatId);
-    if (!orch) throw new Error("Admin orchestrator missing — this should be impossible");
-    return orch;
+  #isAdminChat(chatId: number | string): boolean {
+    return chatId.toString() === this.#config.adminChatId;
   }
 
   #resolveOrchestrator(chatId: number | string): Orchestrator | undefined {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,7 @@
 import type { Bot } from "grammy";
 import { AuthorizedChats, DuplicateChatError, InvalidChatNameError, UnknownChatError } from "./authorized-chats";
 import { createLogger } from "./logger";
-import { type Claude, Orchestrator, type OrchestratorResponse } from "./orchestrator";
+import { type ButtonSpec, type Claude, Orchestrator, type OrchestratorResponse } from "./orchestrator";
 import { type MissedInfo, Scheduler } from "./scheduler";
 import { clearMainSession } from "./sessions";
 import type { SpeechToText } from "./speech-to-text";
@@ -84,8 +84,8 @@ export class App {
       { command: "sessions", description: "List running sessions" },
       { command: "clear", description: "Clear session and start fresh" },
       { command: "chats", description: "List authorized chats (admin only)" },
-      { command: "chats_add", description: "Authorize a new chat (admin only)" },
-      { command: "chats_remove", description: "Remove an authorized chat (admin only)" },
+      { command: "chatsadd", description: "Authorize a new chat (admin only)" },
+      { command: "chatsremove", description: "Remove an authorized chat (admin only)" },
     ]).catch((err) => log.error({ err }, "Failed to set commands"));
     this.#bot.start({
       onStart: (botInfo) => {
@@ -121,6 +121,26 @@ export class App {
 
   #isAdminChat(chatId: number | string): boolean {
     return chatId.toString() === this.#config.adminChatId;
+  }
+
+  async #removeChatByName(name: string, replyChatId: string): Promise<void> {
+    try {
+      const chat = this.#authorizedChats.remove(name);
+      const orch = this.#orchestrators.get(chat.chatId);
+      if (orch) {
+        await orch.dispose();
+        this.#orchestrators.delete(chat.chatId);
+      }
+      clearMainSession(name, this.#config.settingsDir);
+      log.info({ chatId: chat.chatId, name }, "Authorized chat removed");
+      sendResponse(this.#bot, replyChatId, `Chat "${name}" removed.`);
+    } catch (err) {
+      if (err instanceof UnknownChatError) {
+        sendResponse(this.#bot, replyChatId, `Error: ${err.message}`);
+      } else {
+        throw err;
+      }
+    }
   }
 
   #resolveOrchestrator(chatId: number | string): Orchestrator | undefined {
@@ -182,13 +202,13 @@ export class App {
       sendResponse(this.#bot, chatIdStr, `Authorized chats:\n${lines}`);
     });
 
-    this.#bot.command("chats-add", (ctx) => {
+    this.#bot.command("chatsadd", (ctx) => {
       if (!this.#isAdminChat(ctx.chat.id)) return;
-      log.debug("Command /chats-add");
+      log.debug("Command /chatsadd");
       const chatIdStr = ctx.chat.id.toString();
       const args = ctx.match?.trim().split(/\s+/);
       if (!args || args.length < 2 || !args[0] || !args[1]) {
-        sendResponse(this.#bot, chatIdStr, "Usage: /chats-add &lt;chatId&gt; &lt;name&gt;");
+        sendResponse(this.#bot, chatIdStr, "Usage: /chatsadd &lt;chatId&gt; &lt;name&gt;");
         return;
       }
       const [newChatId, name] = args;
@@ -206,32 +226,34 @@ export class App {
       }
     });
 
-    this.#bot.command("chats-remove", async (ctx) => {
-      if (!this.#isAdminChat(ctx.chat.id)) return;
-      log.debug("Command /chats-remove");
+    this.#bot.command("chatsremove", async (ctx) => {
+      log.debug("Command /chatsremove");
       const chatIdStr = ctx.chat.id.toString();
       const name = ctx.match?.trim();
+      const isAdmin = this.#isAdminChat(ctx.chat.id);
+
       if (!name) {
-        sendResponse(this.#bot, chatIdStr, "Usage: /chats-remove &lt;name&gt;");
+        if (!isAdmin) {
+          // Non-admin chat with no arg: self-removal
+          const self = this.#authorizedChats.byChatId(chatIdStr);
+          if (!self) return;
+          await this.#removeChatByName(self.name, chatIdStr);
+          return;
+        }
+        const chats = this.#authorizedChats.list();
+        if (chats.length === 0) {
+          sendResponse(this.#bot, chatIdStr, "No authorized chats to remove.");
+          return;
+        }
+        const buttons: ButtonSpec[] = chats.map((c) => ({ text: c.name, data: `chatsremove:${c.name}` }));
+        buttons.push({ text: "Dismiss", data: "_dismiss" });
+        sendResponse(this.#bot, chatIdStr, "Which chat to remove?", buttons);
         return;
       }
-      try {
-        const chat = this.#authorizedChats.remove(name);
-        const orch = this.#orchestrators.get(chat.chatId);
-        if (orch) {
-          await orch.dispose();
-          this.#orchestrators.delete(chat.chatId);
-        }
-        clearMainSession(name, this.#config.settingsDir);
-        log.info({ chatId: chat.chatId, name }, "Authorized chat removed");
-        sendResponse(this.#bot, chatIdStr, `Chat "${name}" removed.`);
-      } catch (err) {
-        if (err instanceof UnknownChatError) {
-          sendResponse(this.#bot, chatIdStr, `Error: ${err.message}`);
-        } else {
-          throw err;
-        }
-      }
+
+      // With explicit name: admin only
+      if (!isAdmin) return;
+      await this.#removeChatByName(name, chatIdStr);
     });
 
     this.#bot.on("message:photo", async (ctx) => {
@@ -321,6 +343,15 @@ export class App {
         await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [[{ text: "✓ Killed", callback_data: "_noop" }]] } });
         log.debug({ sessionId }, "Kill requested");
         orch.handleKill(sessionId);
+        return;
+      }
+
+      if (data.startsWith("chatsremove:")) {
+        if (!this.#isAdminChat(chatId)) return;
+        const name = data.slice("chatsremove:".length);
+        await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [[{ text: `✓ Removed ${name}`, callback_data: "_noop" }]] } });
+        log.debug({ name }, "Chat removal requested via button");
+        await this.#removeChatByName(name, chatId.toString());
         return;
       }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,7 +9,7 @@ const log = createLogger("app");
 
 export interface AppConfig {
   botToken: string;
-  authorizedChatId: string;
+  adminChatId: string;
   workspace: string;
   model: string;
   timeZone: string;
@@ -63,7 +63,7 @@ export class App {
     ]).catch((err) => log.error({ err }, "Failed to set commands"));
     this.#bot.start({
       onStart: (botInfo) => {
-        log.info({ username: botInfo.username, chatId: this.#config.authorizedChatId }, "Bot connected");
+        log.info({ username: botInfo.username, chatId: this.#config.adminChatId }, "Bot connected");
       },
     });
   }
@@ -71,10 +71,10 @@ export class App {
   async #deliverResponse(response: OrchestratorResponse) {
     if (response.files?.length) {
       for (const filePath of response.files) {
-        await sendFile(this.#bot, this.#config.authorizedChatId, filePath);
+        await sendFile(this.#bot, this.#config.adminChatId, filePath);
       }
     }
-    await sendResponse(this.#bot, this.#config.authorizedChatId, response.message, response.buttons);
+    await sendResponse(this.#bot, this.#config.adminChatId, response.message, response.buttons);
   }
 
   #setupHandlers() {
@@ -84,11 +84,11 @@ export class App {
     });
 
     this.#bot.command("bg", (ctx) => {
-      if (ctx.chat.id.toString() !== this.#config.authorizedChatId) return;
+      if (ctx.chat.id.toString() !== this.#config.adminChatId) return;
       const prompt = ctx.match?.trim();
       if (!prompt) {
         log.debug("Command /bg without prompt");
-        sendResponse(this.#bot, this.#config.authorizedChatId, "Usage: /bg &lt;prompt&gt;");
+        sendResponse(this.#bot, this.#config.adminChatId, "Usage: /bg &lt;prompt&gt;");
         return;
       }
       log.debug({ prompt }, "Command /bg spawn");
@@ -96,19 +96,19 @@ export class App {
     });
 
     this.#bot.command("sessions", (ctx) => {
-      if (ctx.chat.id.toString() !== this.#config.authorizedChatId) return;
+      if (ctx.chat.id.toString() !== this.#config.adminChatId) return;
       log.debug("Command /sessions");
       this.#orchestrator.handleSessions();
     });
 
     this.#bot.command("clear", (ctx) => {
-      if (ctx.chat.id.toString() !== this.#config.authorizedChatId) return;
+      if (ctx.chat.id.toString() !== this.#config.adminChatId) return;
       log.debug("Command /clear");
       this.#orchestrator.handleClear();
     });
 
     this.#bot.on("message:photo", async (ctx) => {
-      if (ctx.chat.id.toString() !== this.#config.authorizedChatId) return;
+      if (ctx.chat.id.toString() !== this.#config.adminChatId) return;
       const photos = ctx.message.photo;
       const largest = photos[photos.length - 1];
       try {
@@ -121,7 +121,7 @@ export class App {
     });
 
     this.#bot.on("message:document", async (ctx) => {
-      if (ctx.chat.id.toString() !== this.#config.authorizedChatId) return;
+      if (ctx.chat.id.toString() !== this.#config.adminChatId) return;
       const doc = ctx.message.document;
       const name = doc.file_name ?? "file";
       try {
@@ -134,23 +134,23 @@ export class App {
     });
 
     this.#bot.on("message:voice", async (ctx) => {
-      if (ctx.chat.id.toString() !== this.#config.authorizedChatId) return;
+      if (ctx.chat.id.toString() !== this.#config.adminChatId) return;
       if (!this.#config.stt) {
-        await sendResponse(this.#bot, this.#config.authorizedChatId, "[Voice messages not available — set openaiApiKey in settings to enable]");
+        await sendResponse(this.#bot, this.#config.adminChatId, "[Voice messages not available — set openaiApiKey in settings to enable]");
         return;
       }
       try {
         const path = await downloadFile(this.#bot, ctx.message.voice.file_id, this.#config.botToken, "voice.ogg");
         const text = await this.#config.stt.transcribe(path);
         if (!text.trim()) {
-          await sendResponse(this.#bot, this.#config.authorizedChatId, "[Could not understand audio]");
+          await sendResponse(this.#bot, this.#config.adminChatId, "[Could not understand audio]");
           return;
         }
-        await sendResponse(this.#bot, this.#config.authorizedChatId, `[Received audio]: ${text}`);
+        await sendResponse(this.#bot, this.#config.adminChatId, `[Received audio]: ${text}`);
         this.#orchestrator.handleMessage(text);
       } catch (err) {
         log.error({ err }, "Voice transcription failed");
-        await sendResponse(this.#bot, this.#config.authorizedChatId, "[Failed to transcribe audio]");
+        await sendResponse(this.#bot, this.#config.adminChatId, "[Failed to transcribe audio]");
       }
     });
 
@@ -158,7 +158,7 @@ export class App {
       await ctx.answerCallbackQuery();
       const data = ctx.callbackQuery.data;
       if (data === "_noop") return;
-      if (ctx.chat?.id.toString() !== this.#config.authorizedChatId) return;
+      if (ctx.chat?.id.toString() !== this.#config.adminChatId) return;
 
       if (data === "_dismiss") {
         await ctx.editMessageReplyMarkup({ reply_markup: undefined });
@@ -195,7 +195,7 @@ export class App {
     });
 
     this.#bot.on("message:text", (ctx) => {
-      if (ctx.chat.id.toString() !== this.#config.authorizedChatId) {
+      if (ctx.chat.id.toString() !== this.#config.adminChatId) {
         log.debug({ chatId: ctx.chat.id }, "Unauthorized message");
         return;
       }

--- a/src/authorized-chats.test.ts
+++ b/src/authorized-chats.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  AuthorizedChats,
+  DuplicateChatError,
+  InvalidChatNameError,
+  UnknownChatError,
+} from "./authorized-chats";
+
+const tmpDir = "/tmp/macroclaw-authorized-chats-test";
+
+function cleanup() {
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
+}
+
+beforeEach(cleanup);
+afterEach(cleanup);
+
+describe("AuthorizedChats.list", () => {
+  it("returns empty array when file does not exist", () => {
+    expect(new AuthorizedChats(tmpDir).list()).toEqual([]);
+  });
+
+  it("reads chats from file", () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, "authorized-chats.json"),
+      JSON.stringify({
+        chats: [
+          { chatId: "-1001", name: "family", addedAt: "2026-04-20T14:00:00.000Z" },
+          { chatId: "987", name: "work", addedAt: "2026-04-21T09:30:00.000Z" },
+        ],
+      }),
+    );
+    expect(new AuthorizedChats(tmpDir).list()).toEqual([
+      { chatId: "-1001", name: "family", addedAt: "2026-04-20T14:00:00.000Z" },
+      { chatId: "987", name: "work", addedAt: "2026-04-21T09:30:00.000Z" },
+    ]);
+  });
+
+  it("returns empty array when file is corrupt", () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(join(tmpDir, "authorized-chats.json"), "not json");
+    expect(new AuthorizedChats(tmpDir).list()).toEqual([]);
+  });
+
+  it("returns empty array when schema validation fails", () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, "authorized-chats.json"),
+      JSON.stringify({ chats: [{ chatId: "not-numeric", name: "x", addedAt: "now" }] }),
+    );
+    expect(new AuthorizedChats(tmpDir).list()).toEqual([]);
+  });
+
+  it("defaults to empty chats when field is missing", () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(join(tmpDir, "authorized-chats.json"), JSON.stringify({}));
+    expect(new AuthorizedChats(tmpDir).list()).toEqual([]);
+  });
+});
+
+describe("AuthorizedChats.add", () => {
+  it("persists new chat to disk", () => {
+    const chats = new AuthorizedChats(tmpDir);
+    const now = new Date("2026-04-20T14:00:00.000Z");
+    chats.add("12345", "family", now);
+    const raw = JSON.parse(readFileSync(join(tmpDir, "authorized-chats.json"), "utf-8"));
+    expect(raw).toEqual({
+      chats: [{ chatId: "12345", name: "family", addedAt: "2026-04-20T14:00:00.000Z" }],
+    });
+  });
+
+  it("uses current time by default", () => {
+    const chats = new AuthorizedChats(tmpDir);
+    const chat = chats.add("12345", "family");
+    expect(chat.addedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("returns the added chat", () => {
+    const chats = new AuthorizedChats(tmpDir);
+    const chat = chats.add("12345", "family", new Date("2026-01-01T00:00:00.000Z"));
+    expect(chat).toEqual({ chatId: "12345", name: "family", addedAt: "2026-01-01T00:00:00.000Z" });
+  });
+
+  it("rejects duplicate name", () => {
+    const chats = new AuthorizedChats(tmpDir);
+    chats.add("111", "family");
+    expect(() => chats.add("222", "family")).toThrow(DuplicateChatError);
+  });
+
+  it("rejects duplicate chatId", () => {
+    const chats = new AuthorizedChats(tmpDir);
+    chats.add("111", "family");
+    expect(() => chats.add("111", "work")).toThrow(DuplicateChatError);
+  });
+
+  it("rejects reserved name 'admin'", () => {
+    const chats = new AuthorizedChats(tmpDir);
+    expect(() => chats.add("111", "admin")).toThrow(InvalidChatNameError);
+  });
+
+  it("rejects invalid name format", () => {
+    const chats = new AuthorizedChats(tmpDir);
+    expect(() => chats.add("111", "Family")).toThrow(InvalidChatNameError);
+    expect(() => chats.add("111", "with space")).toThrow(InvalidChatNameError);
+    expect(() => chats.add("111", "")).toThrow(InvalidChatNameError);
+  });
+
+  it("accepts valid names with digits and dashes", () => {
+    const chats = new AuthorizedChats(tmpDir);
+    expect(() => chats.add("111", "family-1")).not.toThrow();
+    expect(() => chats.add("222", "project2")).not.toThrow();
+  });
+});
+
+describe("AuthorizedChats.remove", () => {
+  it("removes chat and persists", () => {
+    const chats = new AuthorizedChats(tmpDir);
+    chats.add("111", "family");
+    chats.add("222", "work");
+    chats.remove("family");
+    expect(chats.list().map((c) => c.name)).toEqual(["work"]);
+
+    // Re-load from disk to confirm persistence
+    const reloaded = new AuthorizedChats(tmpDir);
+    expect(reloaded.list().map((c) => c.name)).toEqual(["work"]);
+  });
+
+  it("returns the removed chat", () => {
+    const chats = new AuthorizedChats(tmpDir);
+    const added = chats.add("111", "family");
+    const removed = chats.remove("family");
+    expect(removed).toEqual(added);
+  });
+
+  it("throws UnknownChatError for missing name", () => {
+    const chats = new AuthorizedChats(tmpDir);
+    expect(() => chats.remove("nonexistent")).toThrow(UnknownChatError);
+  });
+});
+
+describe("AuthorizedChats.byName / byChatId", () => {
+  it("byName finds a chat", () => {
+    const chats = new AuthorizedChats(tmpDir);
+    chats.add("111", "family");
+    expect(chats.byName("family")?.chatId).toBe("111");
+    expect(chats.byName("unknown")).toBeUndefined();
+  });
+
+  it("byChatId finds a chat", () => {
+    const chats = new AuthorizedChats(tmpDir);
+    chats.add("111", "family");
+    expect(chats.byChatId("111")?.name).toBe("family");
+    expect(chats.byChatId("999")).toBeUndefined();
+  });
+});
+
+describe("AuthorizedChats.validateName", () => {
+  it("throws for 'admin'", () => {
+    expect(() => AuthorizedChats.validateName("admin")).toThrow(InvalidChatNameError);
+  });
+
+  it("throws for invalid characters", () => {
+    expect(() => AuthorizedChats.validateName("Capital")).toThrow(InvalidChatNameError);
+    expect(() => AuthorizedChats.validateName("with_underscore")).toThrow(InvalidChatNameError);
+  });
+
+  it("accepts valid names", () => {
+    expect(() => AuthorizedChats.validateName("family")).not.toThrow();
+    expect(() => AuthorizedChats.validateName("a-b-c")).not.toThrow();
+    expect(() => AuthorizedChats.validateName("x123")).not.toThrow();
+  });
+});
+
+describe("errors", () => {
+  it("DuplicateChatError carries kind and value", () => {
+    const err = new DuplicateChatError("name", "family");
+    expect(err.kind).toBe("name");
+    expect(err.value).toBe("family");
+    expect(err.message).toContain("family");
+  });
+
+  it("UnknownChatError carries chatName", () => {
+    const err = new UnknownChatError("ghost");
+    expect(err.chatName).toBe("ghost");
+    expect(err.message).toContain("ghost");
+  });
+
+  it("InvalidChatNameError carries chatName", () => {
+    const err = new InvalidChatNameError("bad name", "contains space");
+    expect(err.chatName).toBe("bad name");
+    expect(err.message).toContain("bad name");
+  });
+});

--- a/src/authorized-chats.ts
+++ b/src/authorized-chats.ts
@@ -1,0 +1,122 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { z } from "zod/v4";
+import { createLogger } from "./logger";
+
+const log = createLogger("authorized-chats");
+
+export const ADMIN_CHAT_NAME = "admin";
+const NAME_PATTERN = /^[a-z0-9-]+$/;
+
+const chatSchema = z.object({
+  chatId: z.string().regex(/^-?\d+$/, "Must be a numeric Telegram chat ID"),
+  name: z.string().regex(NAME_PATTERN, "Name must be lowercase alphanumeric or dashes"),
+  addedAt: z.string(),
+});
+
+const fileSchema = z.object({
+  chats: z.array(chatSchema).default([]),
+});
+
+export type AuthorizedChat = z.infer<typeof chatSchema>;
+export type AuthorizedChatsFile = z.infer<typeof fileSchema>;
+
+const defaultDir = resolve(process.env.HOME || "~", ".macroclaw");
+
+export class DuplicateChatError extends Error {
+  constructor(public readonly kind: "name" | "chatId", public readonly value: string) {
+    super(`Chat with ${kind} "${value}" is already authorized`);
+  }
+}
+
+export class InvalidChatNameError extends Error {
+  constructor(public readonly chatName: string, reason: string) {
+    super(`Invalid chat name "${chatName}": ${reason}`);
+  }
+}
+
+export class UnknownChatError extends Error {
+  constructor(public readonly chatName: string) {
+    super(`No authorized chat named "${chatName}"`);
+  }
+}
+
+export class AuthorizedChats {
+  readonly #dir: string;
+  #chats: AuthorizedChat[] = [];
+
+  constructor(dir: string = defaultDir) {
+    this.#dir = dir;
+    this.#chats = this.#loadFromDisk();
+  }
+
+  list(): readonly AuthorizedChat[] {
+    return this.#chats;
+  }
+
+  byName(name: string): AuthorizedChat | undefined {
+    return this.#chats.find((c) => c.name === name);
+  }
+
+  byChatId(chatId: string): AuthorizedChat | undefined {
+    return this.#chats.find((c) => c.chatId === chatId);
+  }
+
+  add(chatId: string, name: string, now: Date = new Date()): AuthorizedChat {
+    AuthorizedChats.validateName(name);
+
+    if (this.byName(name)) throw new DuplicateChatError("name", name);
+    if (this.byChatId(chatId)) throw new DuplicateChatError("chatId", chatId);
+
+    const chat = chatSchema.parse({ chatId, name, addedAt: now.toISOString() });
+    this.#chats.push(chat);
+    this.#persist();
+    return chat;
+  }
+
+  remove(name: string): AuthorizedChat {
+    const existing = this.byName(name);
+    if (!existing) throw new UnknownChatError(name);
+    this.#chats = this.#chats.filter((c) => c.name !== name);
+    this.#persist();
+    return existing;
+  }
+
+  static validateName(name: string): void {
+    if (name === ADMIN_CHAT_NAME) {
+      throw new InvalidChatNameError(name, `"${ADMIN_CHAT_NAME}" is reserved`);
+    }
+    if (!NAME_PATTERN.test(name)) {
+      throw new InvalidChatNameError(name, "must be lowercase alphanumeric or dashes");
+    }
+  }
+
+  #loadFromDisk(): AuthorizedChat[] {
+    const path = this.#path();
+    if (!existsSync(path)) return [];
+    try {
+      const raw = JSON.parse(readFileSync(path, "utf-8"));
+      const result = fileSchema.safeParse(raw);
+      if (!result.success) {
+        log.warn(
+          { issues: result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`) },
+          "authorized-chats.json validation failed; starting with empty list",
+        );
+        return [];
+      }
+      return result.data.chats;
+    } catch (err) {
+      log.warn({ err }, "Failed to load authorized-chats.json; starting with empty list");
+      return [];
+    }
+  }
+
+  #persist(): void {
+    mkdirSync(this.#dir, { recursive: true });
+    writeFileSync(this.#path(), `${JSON.stringify({ chats: this.#chats }, null, 2)}\n`);
+  }
+
+  #path(): string {
+    return join(this.#dir, "authorized-chats.json");
+  }
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -20,7 +20,7 @@ const { main } = await import("./cli");
 
 function createMockWizard(overrides?: { collectSettings?: (defaults?: Record<string, unknown>) => Promise<unknown>; installService?: () => Promise<void>; forceInstallService?: () => Promise<void> }) {
 	return {
-		collectSettings: overrides?.collectSettings ?? mock(async () => ({ botToken: "tok", chatId: "123" })),
+		collectSettings: overrides?.collectSettings ?? mock(async () => ({ botToken: "tok", adminChatId: "123" })),
 		installService: overrides?.installService ?? mock(async () => {}),
 		forceInstallService: overrides?.forceInstallService ?? mock(async () => {}),
 	} as unknown as SetupWizard;
@@ -28,7 +28,7 @@ function createMockWizard(overrides?: { collectSettings?: (defaults?: Record<str
 
 function createMockSettings(overrides?: Partial<SettingsManager>) {
 	return {
-		load: mock(() => ({ botToken: "tok", chatId: "123", model: "sonnet", workspace: "/tmp" })),
+		load: mock(() => ({ botToken: "tok", adminChatId: "123", model: "sonnet", workspace: "/tmp" })),
 		loadRaw: mock(() => null),
 		save: mock(() => {}),
 		applyEnvOverrides: mock((s: unknown) => ({ settings: s, overrides: new Set() })),
@@ -72,14 +72,14 @@ describe("Cli.setup", () => {
 		const settings = createMockSettings();
 		const cli = new Cli({ wizard, settings });
 		await cli.setup();
-		expect((settings.save as ReturnType<typeof mock>)).toHaveBeenCalledWith({ botToken: "tok", chatId: "123" });
+		expect((settings.save as ReturnType<typeof mock>)).toHaveBeenCalledWith({ botToken: "tok", adminChatId: "123" });
 	});
 
 	it("passes existing settings as defaults to wizard", async () => {
-		const existing = { botToken: "old-tok", chatId: "999" };
+		const existing = { botToken: "old-tok", adminChatId: "999" };
 		let receivedDefaults: unknown = null;
 		const wizard = createMockWizard({
-			collectSettings: async (defaults) => { receivedDefaults = defaults; return { botToken: "tok", chatId: "123" }; },
+			collectSettings: async (defaults) => { receivedDefaults = defaults; return { botToken: "tok", adminChatId: "123" }; },
 		});
 		const settings = createMockSettings({ loadRaw: () => existing } as unknown as Partial<SettingsManager>);
 		const cli = new Cli({ wizard, settings });
@@ -236,7 +236,7 @@ describe("Cli.claude", () => {
 		const fs = await import("node:fs");
 		const dir = `/tmp/macroclaw-test-claude-${Date.now()}`;
 		fs.mkdirSync(dir, { recursive: true });
-		fs.writeFileSync(`${dir}/settings.json`, JSON.stringify({ botToken: "tok", chatId: "123", model: "opus", workspace: "/tmp" }));
+		fs.writeFileSync(`${dir}/settings.json`, JSON.stringify({ botToken: "tok", adminChatId: "123", model: "opus", workspace: "/tmp" }));
 		fs.writeFileSync(`${dir}/sessions.json`, JSON.stringify({ mainSessionId: "sess-123" }));
 
 		mockExecSync.mockClear();
@@ -257,7 +257,7 @@ describe("Cli.claude", () => {
 		const fs = await import("node:fs");
 		const dir = `/tmp/macroclaw-test-claude-${Date.now()}`;
 		fs.mkdirSync(dir, { recursive: true });
-		fs.writeFileSync(`${dir}/settings.json`, JSON.stringify({ botToken: "tok", chatId: "123", model: "sonnet", workspace: "/tmp" }));
+		fs.writeFileSync(`${dir}/settings.json`, JSON.stringify({ botToken: "tok", adminChatId: "123", model: "sonnet", workspace: "/tmp" }));
 		fs.writeFileSync(`${dir}/sessions.json`, JSON.stringify({}));
 
 		mockExecSync.mockClear();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@ import {execSync} from "node:child_process";
 import {createInterface} from "node:readline";
 import {defineCommand} from "citty";
 import pkg from "../package.json" with {type: "json"};
-import {loadSessions} from "./sessions";
+import {getMainSession} from "./sessions";
 import {SettingsManager} from "./settings";
 import {type SetupIo, SetupWizard} from "./setup";
 import {SystemServiceManager} from "./system-service";
@@ -32,9 +32,9 @@ export class Cli {
 
 	claude(): void {
 		const settings = this.#settingsManager.load();
-		const sessions = loadSessions(this.#settingsManager.dir);
+		const adminSession = getMainSession("admin", this.#settingsManager.dir);
 		const args = ["claude"];
-		if (sessions.mainSessionId) args.push("--resume", sessions.mainSessionId);
+		if (adminSession) args.push("--resume", adminSession);
 		args.push("--model", settings.model);
 		execSync(args.join(" "), { cwd: settings.workspace, stdio: "inherit", env: { ...process.env, CLAUDECODE: "" } });
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export async function start(): Promise<void> {
 
   const config: AppConfig = {
     botToken: resolved.botToken,
-    authorizedChatId: resolved.chatId,
+    adminChatId: resolved.adminChatId,
     workspace,
     model: resolved.model,
     timeZone: resolved.timeZone,

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -263,7 +263,7 @@ describe("Orchestrator", () => {
     });
 
     it("reports error when resume fails", async () => {
-      saveSessions({ mainSessionId: "old-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "old-session" } }, tmpSettingsDir);
       const claude = mockClaude((): ClaudeProcess<unknown> => {
         const proc = autoProcess(null, "old-session");
         (proc as any).send = mock(async () => { throw new QueryProcessError(1, "session not found"); });
@@ -282,7 +282,7 @@ describe("Orchestrator", () => {
 
   describe("session management", () => {
     it("uses resumeSession for existing session", async () => {
-      saveSessions({ mainSessionId: "existing-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "existing-session" } }, tmpSettingsDir);
       const claude = mockClaude({ action: "send", message: "ok", actionReason: "ok" });
       const { orch } = makeOrchestrator(claude);
 
@@ -320,7 +320,7 @@ describe("Orchestrator", () => {
     });
 
     it("background-agent forks from main session", async () => {
-      saveSessions({ mainSessionId: "main-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "main-session" } }, tmpSettingsDir);
       const claude = mockClaude({ action: "send", message: "ok", actionReason: "ok" });
       const { orch } = makeOrchestrator(claude);
 
@@ -449,7 +449,7 @@ describe("Orchestrator", () => {
     });
 
     it("delivers result with error when session not in runningSessions", async () => {
-      saveSessions({ mainSessionId: "main-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "main-session" } }, tmpSettingsDir);
       const { process: mainProc, resolve } = pendingProcess("main-session");
       const claude = mockClaude(() => mainProc);
       const { orch, responses } = makeOrchestrator(claude);
@@ -539,7 +539,7 @@ describe("Orchestrator", () => {
 
   describe("cron routing", () => {
     it("cron always forks as background, never goes through queue", async () => {
-      saveSessions({ mainSessionId: "main-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "main-session" } }, tmpSettingsDir);
       const claude = mockClaude({ action: "send", message: "ok", actionReason: "ok" });
       const { orch } = makeOrchestrator(claude);
 
@@ -553,7 +553,7 @@ describe("Orchestrator", () => {
     });
 
     it("cron uses config model when none specified", async () => {
-      saveSessions({ mainSessionId: "main-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "main-session" } }, tmpSettingsDir);
       const claude = mockClaude({ action: "send", message: "ok", actionReason: "ok" });
       const { orch } = makeOrchestrator(claude, { model: "sonnet" });
 
@@ -564,7 +564,7 @@ describe("Orchestrator", () => {
     });
 
     it("cron result feeds back into main session", async () => {
-      saveSessions({ mainSessionId: "main-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "main-session" } }, tmpSettingsDir);
       let callCount = 0;
       const claude = mockClaude((): ClaudeProcess<unknown> => {
         callCount++;
@@ -591,7 +591,7 @@ describe("Orchestrator", () => {
     });
 
     it("includes detail buttons and dismiss when sessions are running", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "test-session" } }, tmpSettingsDir);
       const claude = mockClaude((): ClaudeProcess<unknown> => {
         const { process } = pendingProcess(`bg-${Date.now()}`);
         return process;
@@ -644,7 +644,7 @@ describe("Orchestrator", () => {
     });
 
     it("peeks at running agent and returns status", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "test-session" } }, tmpSettingsDir);
       let callCount = 0;
       const claude = mockClaude((): ClaudeProcess<unknown> => {
         callCount++;
@@ -674,7 +674,7 @@ describe("Orchestrator", () => {
     });
 
     it("handles Claude error during peek gracefully", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "test-session" } }, tmpSettingsDir);
       let callCount = 0;
       const claude = mockClaude((): ClaudeProcess<unknown> => {
         callCount++;
@@ -717,7 +717,7 @@ describe("Orchestrator", () => {
     });
 
     it("shows session details with peek/kill/dismiss buttons", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "test-session" } }, tmpSettingsDir);
       const claude = mockClaude((): ClaudeProcess<unknown> => {
         const { process } = pendingProcess("bg-sid");
         return process;
@@ -748,7 +748,7 @@ describe("Orchestrator", () => {
     });
 
     it("truncates prompt at 300 chars", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "test-session" } }, tmpSettingsDir);
       const longPrompt = "a".repeat(500);
       const claude = mockClaude((): ClaudeProcess<unknown> => {
         const { process } = pendingProcess("bg-sid");
@@ -775,7 +775,7 @@ describe("Orchestrator", () => {
     });
 
     it("shows model when specified", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "test-session" } }, tmpSettingsDir);
       const claude = mockClaude((): ClaudeProcess<unknown> => {
         const { process } = pendingProcess("bg-sid");
         return process;
@@ -834,7 +834,7 @@ describe("Orchestrator", () => {
     });
 
     it("kills running session and sends confirmation", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "test-session" } }, tmpSettingsDir);
       const { process: bgProc } = pendingProcess("bg-sid");
       const claude = mockClaude((): ClaudeProcess<unknown> => bgProc);
       const { orch, responses } = makeOrchestrator(claude);
@@ -862,7 +862,7 @@ describe("Orchestrator", () => {
     });
 
     it("does not feed error back to queue after kill", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "test-session" } }, tmpSettingsDir);
       const { process: bgProc, reject: rejectBg } = pendingProcess("bg-sid");
       const claude = mockClaude((): ClaudeProcess<unknown> => bgProc);
       const { orch, responses } = makeOrchestrator(claude);
@@ -890,7 +890,7 @@ describe("Orchestrator", () => {
 
   describe("handleBackgroundCommand", () => {
     it("spawns background agent and sends started message", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "test-session" } }, tmpSettingsDir);
       const claude = mockClaude((): ClaudeProcess<unknown> => {
         const { process } = pendingProcess("bg-sid");
         return process;
@@ -907,7 +907,7 @@ describe("Orchestrator", () => {
 
   describe("background management", () => {
     it("spawns background agent and feeds result back to queue", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "test-session" } }, tmpSettingsDir);
       const { process: bgProc, resolve: resolveBg } = pendingProcess("bg-sid");
 
       let callCount = 0;
@@ -931,7 +931,7 @@ describe("Orchestrator", () => {
     });
 
     it("passes action and actionReason through result XML for silent background agent", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "test-session" } }, tmpSettingsDir);
       const { process: bgProc, resolve: resolveBg } = pendingProcess("bg-sid");
 
       let callCount = 0;
@@ -957,7 +957,7 @@ describe("Orchestrator", () => {
     });
 
     it("feeds error back to queue on spawn failure", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "test-session" } }, tmpSettingsDir);
       const { process: bgProc, reject: rejectBg } = pendingProcess("bg-sid");
 
       let callCount = 0;
@@ -981,7 +981,7 @@ describe("Orchestrator", () => {
 
   describe("health checks", () => {
     it("runs health check after interval and reports finished agent", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "test-session" } }, tmpSettingsDir);
       const { process: bgProc } = pendingProcess("bg-sid");
 
       let callCount = 0;
@@ -1013,7 +1013,7 @@ describe("Orchestrator", () => {
     });
 
     it("reports progress and schedules next check when not finished", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "test-session" } }, tmpSettingsDir);
       const { process: bgProc } = pendingProcess("bg-sid");
 
       let hcCount = 0;
@@ -1045,7 +1045,7 @@ describe("Orchestrator", () => {
     });
 
     it("kills unresponsive agent on health check timeout", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "test-session" } }, tmpSettingsDir);
       const { process: bgProc } = pendingProcess("bg-sid");
 
       const claude = mockClaude((info: CallInfo): ClaudeProcess<unknown> => {
@@ -1070,7 +1070,7 @@ describe("Orchestrator", () => {
     });
 
     it("does not run health checks when interval is 0", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "test-session" } }, tmpSettingsDir);
       const { process: bgProc } = pendingProcess("bg-sid");
 
       const claude = mockClaude((): ClaudeProcess<unknown> => bgProc);
@@ -1084,7 +1084,7 @@ describe("Orchestrator", () => {
     });
 
     it("clears health check timer when session is killed", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "test-session" } }, tmpSettingsDir);
       const { process: bgProc } = pendingProcess("bg-sid");
 
       let hcCount = 0;
@@ -1106,7 +1106,7 @@ describe("Orchestrator", () => {
     });
 
     it("stops health check if session completes organically before timer", async () => {
-      saveSessions({ mainSessionId: "test-session" }, tmpSettingsDir);
+      saveSessions({ mainSessions: { admin: "test-session" } }, tmpSettingsDir);
       const { process: bgProc, resolve: resolveBg } = pendingProcess("bg-sid");
 
       let hcCount = 0;

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -12,7 +12,7 @@ import { createLogger } from "./logger";
 import { generateName } from "./naming";
 import { PromptBuilder } from "./prompt-builder";
 import { Queue } from "./queue";
-import { loadSessions, saveSessions } from "./sessions";
+import { clearMainSession, getMainSession, setMainSession } from "./sessions";
 
 type ButtonSpec = string | { text: string; data: string };
 
@@ -128,7 +128,7 @@ export class Orchestrator {
     this.#queue = new Queue<OrchestratorRequest>();
     this.#queue.setHandler((request) => this.#handleRequest(request));
 
-    this.#mainSessionId = loadSessions(config.settingsDir).mainSessionId;
+    this.#mainSessionId = getMainSession("admin", config.settingsDir);
   }
 
   // --- Public handle methods ---
@@ -264,7 +264,7 @@ export class Orchestrator {
       this.#mainProcess = null;
     }
     this.#mainSessionId = undefined;
-    saveSessions({}, this.#config.settingsDir);
+    clearMainSession("admin", this.#config.settingsDir);
     log.info("Session cleared");
     this.#callOnResponse({ message: "Session cleared." });
   }
@@ -294,7 +294,7 @@ export class Orchestrator {
 
     if (this.#mainProcess.sessionId !== this.#mainSessionId) {
       this.#mainSessionId = this.#mainProcess.sessionId;
-      saveSessions({ mainSessionId: this.#mainSessionId }, this.#config.settingsDir);
+      setMainSession("admin", this.#mainSessionId, this.#config.settingsDir);
     }
 
     log.info({ sessionId: this.#mainSessionId }, "Main process created");
@@ -340,7 +340,7 @@ export class Orchestrator {
         { model: this.#config.model },
       );
       this.#mainSessionId = this.#mainProcess.sessionId;
-      saveSessions({ mainSessionId: this.#mainSessionId }, this.#config.settingsDir);
+      setMainSession("admin", this.#mainSessionId, this.#config.settingsDir);
     }
 
     await writeHistoryPrompt(request);

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -123,7 +123,7 @@ export class Orchestrator {
   constructor(config: OrchestratorConfig) {
     this.#config = config;
     this.#chatName = config.chatName ?? "admin";
-    this.#prompts = new PromptBuilder(config.timeZone);
+    this.#prompts = new PromptBuilder(config.timeZone, this.#chatName);
     const envVars: Record<string, string> = { TZ: config.timeZone };
     this.#claude = config.claude ?? new Claude({ workspace: config.workspace, systemPrompt: this.#prompts.systemPrompt, envVars });
     this.#waitThreshold = config.waitThreshold ?? WAIT_THRESHOLD;

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -90,6 +90,8 @@ interface SessionInfo {
 }
 
 export interface OrchestratorConfig {
+  /** Name of the chat this orchestrator serves. Used to scope the sessions.json slot. Defaults to "admin". */
+  chatName?: string;
   model: string;
   workspace: string;
   timeZone: string;
@@ -106,6 +108,7 @@ export interface OrchestratorConfig {
 
 export class Orchestrator {
   #config: Omit<OrchestratorConfig , 'claude'>;
+  #chatName: string;
   #claude: Claude;
   #prompts: PromptBuilder;
   #waitThreshold: number;
@@ -119,6 +122,7 @@ export class Orchestrator {
 
   constructor(config: OrchestratorConfig) {
     this.#config = config;
+    this.#chatName = config.chatName ?? "admin";
     this.#prompts = new PromptBuilder(config.timeZone);
     const envVars: Record<string, string> = { TZ: config.timeZone };
     this.#claude = config.claude ?? new Claude({ workspace: config.workspace, systemPrompt: this.#prompts.systemPrompt, envVars });
@@ -128,7 +132,7 @@ export class Orchestrator {
     this.#queue = new Queue<OrchestratorRequest>();
     this.#queue.setHandler((request) => this.#handleRequest(request));
 
-    this.#mainSessionId = getMainSession("admin", config.settingsDir);
+    this.#mainSessionId = getMainSession(this.#chatName, config.settingsDir);
   }
 
   // --- Public handle methods ---
@@ -264,7 +268,7 @@ export class Orchestrator {
       this.#mainProcess = null;
     }
     this.#mainSessionId = undefined;
-    clearMainSession("admin", this.#config.settingsDir);
+    clearMainSession(this.#chatName, this.#config.settingsDir);
     log.info("Session cleared");
     this.#callOnResponse({ message: "Session cleared." });
   }
@@ -294,7 +298,7 @@ export class Orchestrator {
 
     if (this.#mainProcess.sessionId !== this.#mainSessionId) {
       this.#mainSessionId = this.#mainProcess.sessionId;
-      setMainSession("admin", this.#mainSessionId, this.#config.settingsDir);
+      setMainSession(this.#chatName, this.#mainSessionId, this.#config.settingsDir);
     }
 
     log.info({ sessionId: this.#mainSessionId }, "Main process created");
@@ -340,7 +344,7 @@ export class Orchestrator {
         { model: this.#config.model },
       );
       this.#mainSessionId = this.#mainProcess.sessionId;
-      setMainSession("admin", this.#mainSessionId, this.#config.settingsDir);
+      setMainSession(this.#chatName, this.#mainSessionId, this.#config.settingsDir);
     }
 
     await writeHistoryPrompt(request);

--- a/src/prompt-builder.test.ts
+++ b/src/prompt-builder.test.ts
@@ -241,3 +241,34 @@ describe("healthCheck", () => {
     expect(result).toContain("<instructions>Report status.</instructions>");
   });
 });
+
+describe("chat tag injection", () => {
+  it("omits chat tag when chatName is not provided", () => {
+    const result = p.userMessage("test", "hello");
+    expect(result).not.toContain("<chat>");
+    expect(result).toMatch(/^<event /);
+  });
+
+  it("prepends chat tag when chatName is provided", () => {
+    const pb = new PromptBuilder("UTC", "family");
+    const result = pb.userMessage("test", "hello");
+    expect(result).toMatch(/^<chat>family<\/chat>\n<event /);
+  });
+
+  it("escapes XML in chat name", () => {
+    const pb = new PromptBuilder("UTC", "a<b>");
+    const result = pb.userMessage("test", "hello");
+    expect(result).toContain("<chat>a&lt;b&gt;</chat>");
+  });
+
+  it("injects chat tag in all prompt methods", () => {
+    const pb = new PromptBuilder("UTC", "admin");
+    expect(pb.buttonClick("t", "Yes")).toContain("<chat>admin</chat>");
+    expect(pb.scheduleTrigger("t", { name: "daily" }, "go")).toContain("<chat>admin</chat>");
+    expect(pb.backgroundAgentStart("t", "task")).toContain("<chat>admin</chat>");
+    expect(pb.backgroundAgentResult("t", "orig", { action: "send", actionReason: "done" })).toContain("<chat>admin</chat>");
+    expect(pb.backgroundAgentProgress("t", "orig", "50%", "keep going")).toContain("<chat>admin</chat>");
+    expect(pb.peek("t", "orig", "status?")).toContain("<chat>admin</chat>");
+    expect(pb.healthCheck("t", "orig", "status?")).toContain("<chat>admin</chat>");
+  });
+});

--- a/src/prompt-builder.test.ts
+++ b/src/prompt-builder.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { PromptBuilder } from "./prompt-builder";
 
-const p = new PromptBuilder("UTC");
+const p = new PromptBuilder("UTC", "admin");
 
 describe("systemPrompt", () => {
   it("contains key sections", () => {
@@ -52,17 +52,22 @@ describe("systemPrompt", () => {
   });
 
   it("includes time zone but not a fixed date", () => {
-    const prague = new PromptBuilder("Europe/Prague");
+    const prague = new PromptBuilder("Europe/Prague", "admin");
     expect(prague.systemPrompt).not.toContain("Current date:");
     expect(prague.systemPrompt).toContain("Timezone: Europe/Prague");
     expect(prague.systemPrompt).toContain("TZ env var is set");
+  });
+
+  it("documents the chat attribute on events", () => {
+    expect(p.systemPrompt).toContain("Multi-chat");
+    expect(p.systemPrompt).toContain("chat — name of the Telegram chat");
   });
 });
 
 describe("userMessage", () => {
   it("builds user message event with time attribute", () => {
     const result = p.userMessage("check-logs", "hello");
-    expect(result).toMatch(/^<event time="\d{4}-\d{2}-\d{2}T\d{2}:\d{2}" name="check-logs" type="user-message" session="main">/);
+    expect(result).toMatch(/^<event time="\d{4}-\d{2}-\d{2}T\d{2}:\d{2}" name="check-logs" chat="admin" type="user-message" session="main">/);
     expect(result).toContain("<text>hello</text>");
     expect(result).toEndWith("</event>");
   });
@@ -242,33 +247,22 @@ describe("healthCheck", () => {
   });
 });
 
-describe("chat tag injection", () => {
-  it("omits chat tag when chatName is not provided", () => {
-    const result = p.userMessage("test", "hello");
-    expect(result).not.toContain("<chat>");
-    expect(result).toMatch(/^<event /);
-  });
-
-  it("prepends chat tag when chatName is provided", () => {
+describe("chat attribute", () => {
+  it("includes chat attribute on every event type", () => {
     const pb = new PromptBuilder("UTC", "family");
-    const result = pb.userMessage("test", "hello");
-    expect(result).toMatch(/^<chat>family<\/chat>\n<event /);
+    expect(pb.userMessage("t", "hello")).toContain('chat="family"');
+    expect(pb.buttonClick("t", "Yes")).toContain('chat="family"');
+    expect(pb.scheduleTrigger("t", { name: "daily" }, "go")).toContain('chat="family"');
+    expect(pb.backgroundAgentStart("t", "task")).toContain('chat="family"');
+    expect(pb.backgroundAgentResult("t", "orig", { action: "send", actionReason: "done" })).toContain('chat="family"');
+    expect(pb.backgroundAgentProgress("t", "orig", "50%", "keep going")).toContain('chat="family"');
+    expect(pb.peek("t", "orig", "status?")).toContain('chat="family"');
+    expect(pb.healthCheck("t", "orig", "status?")).toContain('chat="family"');
   });
 
   it("escapes XML in chat name", () => {
-    const pb = new PromptBuilder("UTC", "a<b>");
+    const pb = new PromptBuilder("UTC", 'a<b>"');
     const result = pb.userMessage("test", "hello");
-    expect(result).toContain("<chat>a&lt;b&gt;</chat>");
-  });
-
-  it("injects chat tag in all prompt methods", () => {
-    const pb = new PromptBuilder("UTC", "admin");
-    expect(pb.buttonClick("t", "Yes")).toContain("<chat>admin</chat>");
-    expect(pb.scheduleTrigger("t", { name: "daily" }, "go")).toContain("<chat>admin</chat>");
-    expect(pb.backgroundAgentStart("t", "task")).toContain("<chat>admin</chat>");
-    expect(pb.backgroundAgentResult("t", "orig", { action: "send", actionReason: "done" })).toContain("<chat>admin</chat>");
-    expect(pb.backgroundAgentProgress("t", "orig", "50%", "keep going")).toContain("<chat>admin</chat>");
-    expect(pb.peek("t", "orig", "status?")).toContain("<chat>admin</chat>");
-    expect(pb.healthCheck("t", "orig", "status?")).toContain("<chat>admin</chat>");
+    expect(result).toContain('chat="a&lt;b&gt;&quot;"');
   });
 });

--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -83,9 +83,11 @@ interface BuildXmlFields {
 
 export class PromptBuilder {
   readonly #timeZone: string;
+  readonly #chatName: string | undefined;
 
-  constructor(timeZone: string) {
+  constructor(timeZone: string, chatName?: string) {
     this.#timeZone = timeZone;
+    this.#chatName = chatName;
   }
 
   get systemPrompt(): string {
@@ -98,6 +100,10 @@ export class PromptBuilder {
 
   static #escapeXml(text: string): string {
     return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  }
+
+  #withChat(xml: string): string {
+    return this.#chatName ? `<chat>${PromptBuilder.#escapeXml(this.#chatName)}</chat>\n${xml}` : xml;
   }
 
   static #buildXml(name: string, type: string, session: string, time: string, fields: BuildXmlFields): string {
@@ -174,34 +180,34 @@ export class PromptBuilder {
   }
 
   userMessage(name: string, text: string, opts?: { files?: string[]; backgroundedEvent?: string }): string {
-    return PromptBuilder.#buildXml(name, "user-message", "main", this.#localTime(), { text, files: opts?.files, backgroundedEvent: opts?.backgroundedEvent });
+    return this.#withChat(PromptBuilder.#buildXml(name, "user-message", "main", this.#localTime(), { text, files: opts?.files, backgroundedEvent: opts?.backgroundedEvent }));
   }
 
   buttonClick(name: string, button: string, opts?: { backgroundedEvent?: string }): string {
-    return PromptBuilder.#buildXml(name, "button-click", "main", this.#localTime(), { button, backgroundedEvent: opts?.backgroundedEvent });
+    return this.#withChat(PromptBuilder.#buildXml(name, "button-click", "main", this.#localTime(), { button, backgroundedEvent: opts?.backgroundedEvent }));
   }
 
   scheduleTrigger(name: string, schedule: { name: string; missedBy?: string; scheduledAt?: string }, text: string): string {
-    return PromptBuilder.#buildXml(name, "schedule-trigger", "background", this.#localTime(), { schedule, text });
+    return this.#withChat(PromptBuilder.#buildXml(name, "schedule-trigger", "background", this.#localTime(), { schedule, text }));
   }
 
   backgroundAgentStart(name: string, text: string): string {
-    return PromptBuilder.#buildXml(name, "background-agent-start", "background", this.#localTime(), { text });
+    return this.#withChat(PromptBuilder.#buildXml(name, "background-agent-start", "background", this.#localTime(), { text }));
   }
 
   backgroundAgentResult(name: string, originalEvent: string, result: { action: string; actionReason: string; text?: string; files?: string[] }, opts?: { backgroundedEvent?: string }): string {
-    return PromptBuilder.#buildXml(name, "background-agent-result", "main", this.#localTime(), { originalEvent, result, backgroundedEvent: opts?.backgroundedEvent });
+    return this.#withChat(PromptBuilder.#buildXml(name, "background-agent-result", "main", this.#localTime(), { originalEvent, result, backgroundedEvent: opts?.backgroundedEvent }));
   }
 
   backgroundAgentProgress(name: string, originalEvent: string, progress: string, instructions: string, opts?: { backgroundedEvent?: string }): string {
-    return PromptBuilder.#buildXml(name, "background-agent-progress", "main", this.#localTime(), { originalEvent, progress, instructions, backgroundedEvent: opts?.backgroundedEvent });
+    return this.#withChat(PromptBuilder.#buildXml(name, "background-agent-progress", "main", this.#localTime(), { originalEvent, progress, instructions, backgroundedEvent: opts?.backgroundedEvent }));
   }
 
   peek(name: string, targetEvent: string, instructions: string): string {
-    return PromptBuilder.#buildXml(name, "peek", "background", this.#localTime(), { targetEvent, instructions });
+    return this.#withChat(PromptBuilder.#buildXml(name, "peek", "background", this.#localTime(), { targetEvent, instructions }));
   }
 
   healthCheck(name: string, targetEvent: string, instructions: string): string {
-    return PromptBuilder.#buildXml(name, "health-check", "background", this.#localTime(), { targetEvent, instructions });
+    return this.#withChat(PromptBuilder.#buildXml(name, "health-check", "background", this.#localTime(), { targetEvent, instructions }));
   }
 }

--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -17,9 +17,16 @@ Use raw <b>, <i>, <code>, <pre> tags. Escape &, <, > in text content as &amp;, &
 Architecture: message bridge connecting chat interface and scheduled tasks. \
 Persistent session — conversation history carries across messages. Workspace persists across sessions.
 
+Multi-chat: the bridge serves multiple Telegram chats (e.g. "admin", "family", "work"). Each chat has its own \
+isolated conversation thread with you. The chat attribute on every <event> identifies which chat the event \
+originates from. Tailor your response to that chat — different people/contexts may expect different tone, \
+access, and information. When responding to a scheduled task with chat="*", the same prompt is being \
+broadcast to every authorized chat.
+
 Event format: every incoming message is wrapped in an <event> XML block. Attributes:
 - time — local time when the event was created (ISO 8601, minute precision).
 - name — short identifier for this event (e.g. "check-logs", "cron-daily").
+- chat — name of the Telegram chat this event belongs to (e.g. "admin", "family").
 - type — what triggered this event. One of:
   - user-message — direct user message. Content in <text>, optional <files>.
   - button-click — user tapped an inline button. Label in <button>.
@@ -83,9 +90,9 @@ interface BuildXmlFields {
 
 export class PromptBuilder {
   readonly #timeZone: string;
-  readonly #chatName: string | undefined;
+  readonly #chatName: string;
 
-  constructor(timeZone: string, chatName?: string) {
+  constructor(timeZone: string, chatName: string) {
     this.#timeZone = timeZone;
     this.#chatName = chatName;
   }
@@ -102,14 +109,10 @@ export class PromptBuilder {
     return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
   }
 
-  #withChat(xml: string): string {
-    return this.#chatName ? `<chat>${PromptBuilder.#escapeXml(this.#chatName)}</chat>\n${xml}` : xml;
-  }
-
-  static #buildXml(name: string, type: string, session: string, time: string, fields: BuildXmlFields): string {
+  #buildXml(name: string, type: string, session: string, time: string, fields: BuildXmlFields): string {
     const esc = PromptBuilder.#escapeXml;
     const lines: string[] = [
-      `<event time="${time}" name="${esc(name)}" type="${type}" session="${session}">`,
+      `<event time="${time}" name="${esc(name)}" chat="${esc(this.#chatName)}" type="${type}" session="${session}">`,
     ];
 
     if (fields.backgroundedEvent) {
@@ -180,34 +183,34 @@ export class PromptBuilder {
   }
 
   userMessage(name: string, text: string, opts?: { files?: string[]; backgroundedEvent?: string }): string {
-    return this.#withChat(PromptBuilder.#buildXml(name, "user-message", "main", this.#localTime(), { text, files: opts?.files, backgroundedEvent: opts?.backgroundedEvent }));
+    return this.#buildXml(name, "user-message", "main", this.#localTime(), { text, files: opts?.files, backgroundedEvent: opts?.backgroundedEvent });
   }
 
   buttonClick(name: string, button: string, opts?: { backgroundedEvent?: string }): string {
-    return this.#withChat(PromptBuilder.#buildXml(name, "button-click", "main", this.#localTime(), { button, backgroundedEvent: opts?.backgroundedEvent }));
+    return this.#buildXml(name, "button-click", "main", this.#localTime(), { button, backgroundedEvent: opts?.backgroundedEvent });
   }
 
   scheduleTrigger(name: string, schedule: { name: string; missedBy?: string; scheduledAt?: string }, text: string): string {
-    return this.#withChat(PromptBuilder.#buildXml(name, "schedule-trigger", "background", this.#localTime(), { schedule, text }));
+    return this.#buildXml(name, "schedule-trigger", "background", this.#localTime(), { schedule, text });
   }
 
   backgroundAgentStart(name: string, text: string): string {
-    return this.#withChat(PromptBuilder.#buildXml(name, "background-agent-start", "background", this.#localTime(), { text }));
+    return this.#buildXml(name, "background-agent-start", "background", this.#localTime(), { text });
   }
 
   backgroundAgentResult(name: string, originalEvent: string, result: { action: string; actionReason: string; text?: string; files?: string[] }, opts?: { backgroundedEvent?: string }): string {
-    return this.#withChat(PromptBuilder.#buildXml(name, "background-agent-result", "main", this.#localTime(), { originalEvent, result, backgroundedEvent: opts?.backgroundedEvent }));
+    return this.#buildXml(name, "background-agent-result", "main", this.#localTime(), { originalEvent, result, backgroundedEvent: opts?.backgroundedEvent });
   }
 
   backgroundAgentProgress(name: string, originalEvent: string, progress: string, instructions: string, opts?: { backgroundedEvent?: string }): string {
-    return this.#withChat(PromptBuilder.#buildXml(name, "background-agent-progress", "main", this.#localTime(), { originalEvent, progress, instructions, backgroundedEvent: opts?.backgroundedEvent }));
+    return this.#buildXml(name, "background-agent-progress", "main", this.#localTime(), { originalEvent, progress, instructions, backgroundedEvent: opts?.backgroundedEvent });
   }
 
   peek(name: string, targetEvent: string, instructions: string): string {
-    return this.#withChat(PromptBuilder.#buildXml(name, "peek", "background", this.#localTime(), { targetEvent, instructions }));
+    return this.#buildXml(name, "peek", "background", this.#localTime(), { targetEvent, instructions });
   }
 
   healthCheck(name: string, targetEvent: string, instructions: string): string {
-    return this.#withChat(PromptBuilder.#buildXml(name, "health-check", "background", this.#localTime(), { targetEvent, instructions }));
+    return this.#buildXml(name, "health-check", "background", this.#localTime(), { targetEvent, instructions });
   }
 }

--- a/src/scheduler.test.ts
+++ b/src/scheduler.test.ts
@@ -17,7 +17,7 @@ function readScheduleConfig() {
 }
 
 function makeOnJob() {
-	return mock((_name: string, _prompt: string, _model?: string, _missed?: { missedBy: string; scheduledAt: string }) => {});
+	return mock((_name: string, _prompt: string, _model?: string, _missed?: { missedBy: string; scheduledAt: string }, _chat?: string) => {});
 }
 
 // Build a cron expression that matches the current minute
@@ -77,7 +77,7 @@ describe("Scheduler — cron jobs", () => {
 		s.start();
 		s.stop();
 
-		expect(onJob).toHaveBeenCalledWith("test-job", "do something", undefined);
+		expect(onJob).toHaveBeenCalledWith("test-job", "do something", undefined, undefined, undefined);
 	});
 
 	it("does not call onJob for non-matching jobs", () => {
@@ -107,7 +107,7 @@ describe("Scheduler — cron jobs", () => {
 		s.stop();
 
 		expect(onJob).toHaveBeenCalledTimes(1);
-		expect(onJob).toHaveBeenCalledWith("good", "good", undefined);
+		expect(onJob).toHaveBeenCalledWith("good", "good", undefined, undefined, undefined);
 	});
 
 	it("handles multiple matching jobs", () => {
@@ -124,8 +124,8 @@ describe("Scheduler — cron jobs", () => {
 		s.stop();
 
 		expect(onJob).toHaveBeenCalledTimes(2);
-		expect(onJob).toHaveBeenCalledWith("first", "first", undefined);
-		expect(onJob).toHaveBeenCalledWith("second", "second", undefined);
+		expect(onJob).toHaveBeenCalledWith("first", "first", undefined, undefined, undefined);
+		expect(onJob).toHaveBeenCalledWith("second", "second", undefined, undefined, undefined);
 	});
 
 	it("passes model override to onJob", () => {
@@ -138,7 +138,20 @@ describe("Scheduler — cron jobs", () => {
 		s.start();
 		s.stop();
 
-		expect(onJob).toHaveBeenCalledWith("smart", "think hard", "opus");
+		expect(onJob).toHaveBeenCalledWith("smart", "think hard", "opus", undefined, undefined);
+	});
+
+	it("passes chat field to onJob for cron jobs", () => {
+		writeScheduleConfig({
+			jobs: [{ name: "targeted-cron", cron: currentMinuteCron(), prompt: "family update", chat: "family" }],
+		});
+
+		const onJob = makeOnJob();
+		const s = new Scheduler(TEST_DIR, { timeZone: "UTC", onJob });
+		s.start();
+		s.stop();
+
+		expect(onJob).toHaveBeenCalledWith("targeted-cron", "family update", undefined, undefined, "family");
 	});
 
 	it("never removes cron jobs after firing", () => {
@@ -168,7 +181,7 @@ describe("Scheduler — fireAt jobs", () => {
 		s.start();
 		s.stop();
 
-		expect(onJob).toHaveBeenCalledWith("now", "do it", undefined);
+		expect(onJob).toHaveBeenCalledWith("now", "do it", undefined, undefined, undefined);
 		expect(onJob.mock.calls[0][3]).toBeUndefined();
 	});
 
@@ -294,7 +307,7 @@ describe("Scheduler — fireAt jobs", () => {
 		s.start();
 		s.stop();
 
-		expect(onJob).toHaveBeenCalledWith("smart", "think", "opus");
+		expect(onJob).toHaveBeenCalledWith("smart", "think", "opus", undefined, undefined);
 	});
 
 	it("interprets offset-less fireAt in the configured time zone", () => {
@@ -316,7 +329,7 @@ describe("Scheduler — fireAt jobs", () => {
 		s.start();
 		s.stop();
 
-		expect(onJob).toHaveBeenCalledWith("local", "local time", undefined);
+		expect(onJob).toHaveBeenCalledWith("local", "local time", undefined, undefined, undefined);
 	});
 
 	it("preserves explicit offset in fireAt (ignores configured time zone)", () => {
@@ -330,7 +343,20 @@ describe("Scheduler — fireAt jobs", () => {
 		s.start();
 		s.stop();
 
-		expect(onJob).toHaveBeenCalledWith("explicit", "with offset", undefined);
+		expect(onJob).toHaveBeenCalledWith("explicit", "with offset", undefined, undefined, undefined);
+	});
+
+	it("passes chat field to onJob", () => {
+		writeScheduleConfig({
+			jobs: [{ name: "targeted", fireAt: justNowFireAt(), prompt: "hi family", chat: "family" }],
+		});
+
+		const onJob = makeOnJob();
+		const s = new Scheduler(TEST_DIR, { timeZone: "UTC", onJob });
+		s.start();
+		s.stop();
+
+		expect(onJob).toHaveBeenCalledWith("targeted", "hi family", undefined, undefined, "family");
 	});
 
 	it("still fires when write-back of schedule.json fails", () => {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -13,6 +13,7 @@ const jobSchema = z.object({
 	model: z.string().optional(),
 	cron: z.string().optional(),
 	fireAt: z.string().optional(),
+	chat: z.string().optional(),
 });
 
 const scheduleConfigSchema = z.object({
@@ -29,7 +30,7 @@ export interface MissedInfo {
 
 export interface SchedulerConfig {
 	timeZone: string;
-	onJob: (name: string, prompt: string, model?: string, missed?: MissedInfo) => void;
+	onJob: (name: string, prompt: string, model?: string, missed?: MissedInfo, chat?: string) => void;
 }
 
 const TICK_INTERVAL = 10_000; // 10 seconds
@@ -118,14 +119,14 @@ export class Scheduler {
 		}
 	}
 
-	#evaluateCronJob(job: { name: string; cron: string; prompt: string; model?: string }, now: Date): void {
+	#evaluateCronJob(job: { name: string; cron: string; prompt: string; model?: string; chat?: string }, now: Date): void {
 		try {
 			const interval = CronExpressionParser.parse(job.cron, { tz: this.#timeZone });
 			const prev = interval.prev();
 			const diff = Math.abs(now.getTime() - prev.getTime());
 			if (diff < 60_000) {
 				log.debug({ name: job.name, cron: job.cron }, "Cron job triggered");
-				this.#config.onJob(job.name, job.prompt, job.model);
+				this.#config.onJob(job.name, job.prompt, job.model, undefined, job.chat);
 			}
 		} catch (err) {
 			log.warn({ cron: job.cron, err: err instanceof Error ? err.message : err }, "Invalid cron expression");
@@ -144,7 +145,7 @@ export class Scheduler {
 	}
 
 	#evaluateFireAtJob(
-		job: { name: string; fireAt: string; prompt: string; model?: string },
+		job: { name: string; fireAt: string; prompt: string; model?: string; chat?: string },
 		now: Date,
 	): "remove" | "keep" {
 		const fireAt = Scheduler.#parseFireAt(job.fireAt, this.#timeZone);
@@ -162,7 +163,7 @@ export class Scheduler {
 
 		if (diff < 60_000) {
 			log.debug({ name: job.name, fireAt: job.fireAt }, "One-shot job triggered");
-			this.#config.onJob(job.name, job.prompt, job.model);
+			this.#config.onJob(job.name, job.prompt, job.model, undefined, job.chat);
 			return "remove";
 		}
 
@@ -172,7 +173,7 @@ export class Scheduler {
 			this.#config.onJob(job.name, job.prompt, job.model, {
 				missedBy: `${missedMinutes}m`,
 				scheduledAt: job.fireAt,
-			});
+			}, job.chat);
 			return "remove";
 		}
 

--- a/src/sessions.test.ts
+++ b/src/sessions.test.ts
@@ -1,7 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { loadSessions, newSessionId, saveSessions } from "./sessions";
+import {
+  clearMainSession,
+  getMainSession,
+  loadSessions,
+  newSessionId,
+  saveSessions,
+  setMainSession,
+} from "./sessions";
 
 const tmpDir = "/tmp/macroclaw-sessions-test";
 
@@ -13,46 +20,105 @@ beforeEach(cleanup);
 afterEach(cleanup);
 
 describe("loadSessions", () => {
-  it("returns empty object when dir does not exist", () => {
-    expect(loadSessions(tmpDir)).toEqual({});
+  it("returns empty sessions when dir does not exist", () => {
+    expect(loadSessions(tmpDir)).toEqual({ mainSessions: {} });
   });
 
-  it("returns empty object when file does not exist", () => {
+  it("returns empty sessions when file does not exist", () => {
     mkdirSync(tmpDir, { recursive: true });
-    expect(loadSessions(tmpDir)).toEqual({});
+    expect(loadSessions(tmpDir)).toEqual({ mainSessions: {} });
   });
 
   it("reads sessions from file", () => {
     mkdirSync(tmpDir, { recursive: true });
-    writeFileSync(join(tmpDir, "sessions.json"), JSON.stringify({ mainSessionId: "abc-123" }));
-    expect(loadSessions(tmpDir)).toEqual({ mainSessionId: "abc-123" });
+    writeFileSync(
+      join(tmpDir, "sessions.json"),
+      JSON.stringify({ mainSessions: { admin: "abc-123", family: "def-456" } }),
+    );
+    expect(loadSessions(tmpDir)).toEqual({
+      mainSessions: { admin: "abc-123", family: "def-456" },
+    });
   });
 
-  it("returns empty object when file is corrupt", () => {
+  it("returns empty sessions when file is corrupt", () => {
     mkdirSync(tmpDir, { recursive: true });
     writeFileSync(join(tmpDir, "sessions.json"), "not json");
-    expect(loadSessions(tmpDir)).toEqual({});
+    expect(loadSessions(tmpDir)).toEqual({ mainSessions: {} });
   });
 
   it("strips unknown fields via schema", () => {
     mkdirSync(tmpDir, { recursive: true });
-    writeFileSync(join(tmpDir, "sessions.json"), JSON.stringify({ mainSessionId: "abc", extra: true }));
-    const result = loadSessions(tmpDir);
-    expect(result).toEqual({ mainSessionId: "abc" });
+    writeFileSync(
+      join(tmpDir, "sessions.json"),
+      JSON.stringify({ mainSessions: { admin: "abc" }, extra: true }),
+    );
+    expect(loadSessions(tmpDir)).toEqual({ mainSessions: { admin: "abc" } });
+  });
+
+  it("migrates legacy mainSessionId to mainSessions.admin", () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(join(tmpDir, "sessions.json"), JSON.stringify({ mainSessionId: "legacy-id" }));
+    expect(loadSessions(tmpDir)).toEqual({ mainSessions: { admin: "legacy-id" } });
+  });
+
+  it("defaults to empty mainSessions when field is missing", () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(join(tmpDir, "sessions.json"), JSON.stringify({}));
+    expect(loadSessions(tmpDir)).toEqual({ mainSessions: {} });
   });
 });
 
 describe("saveSessions", () => {
   it("creates directory and writes file", () => {
-    saveSessions({ mainSessionId: "new-id" }, tmpDir);
-    const saved = loadSessions(tmpDir);
-    expect(saved).toEqual({ mainSessionId: "new-id" });
+    saveSessions({ mainSessions: { admin: "new-id" } }, tmpDir);
+    expect(loadSessions(tmpDir)).toEqual({ mainSessions: { admin: "new-id" } });
   });
 
   it("overwrites existing file", () => {
-    saveSessions({ mainSessionId: "first" }, tmpDir);
-    saveSessions({ mainSessionId: "second" }, tmpDir);
-    expect(loadSessions(tmpDir)).toEqual({ mainSessionId: "second" });
+    saveSessions({ mainSessions: { admin: "first" } }, tmpDir);
+    saveSessions({ mainSessions: { admin: "second" } }, tmpDir);
+    expect(loadSessions(tmpDir)).toEqual({ mainSessions: { admin: "second" } });
+  });
+});
+
+describe("getMainSession / setMainSession / clearMainSession", () => {
+  it("returns undefined when no session for chat", () => {
+    expect(getMainSession("admin", tmpDir)).toBeUndefined();
+  });
+
+  it("returns stored session id", () => {
+    saveSessions({ mainSessions: { admin: "abc", family: "def" } }, tmpDir);
+    expect(getMainSession("admin", tmpDir)).toBe("abc");
+    expect(getMainSession("family", tmpDir)).toBe("def");
+  });
+
+  it("setMainSession preserves other chats", () => {
+    saveSessions({ mainSessions: { admin: "abc", family: "def" } }, tmpDir);
+    setMainSession("admin", "new-admin-id", tmpDir);
+    expect(loadSessions(tmpDir)).toEqual({
+      mainSessions: { admin: "new-admin-id", family: "def" },
+    });
+  });
+
+  it("setMainSession adds new chat without touching others", () => {
+    saveSessions({ mainSessions: { admin: "abc" } }, tmpDir);
+    setMainSession("work", "work-id", tmpDir);
+    expect(loadSessions(tmpDir)).toEqual({
+      mainSessions: { admin: "abc", work: "work-id" },
+    });
+  });
+
+  it("clearMainSession removes one chat, preserves others", () => {
+    saveSessions({ mainSessions: { admin: "abc", family: "def" } }, tmpDir);
+    clearMainSession("family", tmpDir);
+    expect(loadSessions(tmpDir)).toEqual({ mainSessions: { admin: "abc" } });
+  });
+
+  it("clearMainSession is a no-op when chat is not present", () => {
+    saveSessions({ mainSessions: { admin: "abc" } }, tmpDir);
+    clearMainSession("nobody", tmpDir);
+    const contents = readFileSync(join(tmpDir, "sessions.json"), "utf-8");
+    expect(JSON.parse(contents)).toEqual({ mainSessions: { admin: "abc" } });
   });
 });
 

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -7,28 +7,56 @@ import { createLogger } from "./logger";
 const log = createLogger("sessions");
 
 const sessionsSchema = z.object({
-  mainSessionId: z.string().optional(),
+  mainSessions: z.record(z.string(), z.string()).default({}),
 });
 
 export type Sessions = z.infer<typeof sessionsSchema>;
 
 const defaultDir = resolve(process.env.HOME || "~", ".macroclaw");
 
+function migrateLegacy(raw: unknown): unknown {
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    const obj = raw as Record<string, unknown>;
+    if (typeof obj.mainSessionId === "string" && obj.mainSessions === undefined) {
+      return { mainSessions: { admin: obj.mainSessionId } };
+    }
+  }
+  return raw;
+}
+
 export function loadSessions(dir: string = defaultDir): Sessions {
   try {
     const path = join(dir, "sessions.json");
-    if (!existsSync(path)) return {};
-    const raw = readFileSync(path, "utf-8");
-    return sessionsSchema.parse(JSON.parse(raw));
+    if (!existsSync(path)) return { mainSessions: {} };
+    const raw = migrateLegacy(JSON.parse(readFileSync(path, "utf-8")));
+    return sessionsSchema.parse(raw);
   } catch (err) {
     log.warn({ err }, "Failed to load sessions.json, resetting to empty");
-    return {};
+    return { mainSessions: {} };
   }
 }
 
 export function saveSessions(sessions: Sessions, dir: string = defaultDir): void {
   mkdirSync(dir, { recursive: true });
   writeFileSync(join(dir, "sessions.json"), `${JSON.stringify(sessions, null, 2)}\n`);
+}
+
+export function getMainSession(chatName: string, dir: string = defaultDir): string | undefined {
+  return loadSessions(dir).mainSessions[chatName];
+}
+
+export function setMainSession(chatName: string, sessionId: string, dir: string = defaultDir): void {
+  const sessions = loadSessions(dir);
+  sessions.mainSessions[chatName] = sessionId;
+  saveSessions(sessions, dir);
+}
+
+export function clearMainSession(chatName: string, dir: string = defaultDir): void {
+  const sessions = loadSessions(dir);
+  if (chatName in sessions.mainSessions) {
+    delete sessions.mainSessions[chatName];
+    saveSessions(sessions, dir);
+  }
 }
 
 export function newSessionId(): string {

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -7,7 +7,7 @@ const tmpDir = "/tmp/macroclaw-settings-test";
 
 const validSettings: Settings = {
   botToken: "123:ABC",
-  chatId: "12345678",
+  adminChatId: "12345678",
   model: "sonnet",
   workspace: "~/.macroclaw-workspace",
   timeZone: "UTC",
@@ -32,12 +32,12 @@ describe("SettingsManager.load", () => {
     mkdirSync(tmpDir, { recursive: true });
     writeFileSync(join(tmpDir, "settings.json"), JSON.stringify({
       botToken: "123:ABC",
-      chatId: "12345678",
+      adminChatId: "12345678",
     }));
     const settings = new SettingsManager(tmpDir).load();
     expect(settings).toEqual({
       botToken: "123:ABC",
-      chatId: "12345678",
+      adminChatId: "12345678",
       model: "sonnet",
       workspace: "~/.macroclaw-workspace",
       timeZone: "UTC",
@@ -49,7 +49,7 @@ describe("SettingsManager.load", () => {
     mkdirSync(tmpDir, { recursive: true });
     writeFileSync(join(tmpDir, "settings.json"), JSON.stringify({
       botToken: "  123:ABC  ",
-      chatId: " 12345678 ",
+      adminChatId: " 12345678 ",
       model: " opus ",
       workspace: "  /custom/workspace  ",
       timeZone: "  Europe/Prague  ",
@@ -60,7 +60,7 @@ describe("SettingsManager.load", () => {
     const settings = new SettingsManager(tmpDir).load();
     expect(settings).toEqual({
       botToken: "123:ABC",
-      chatId: "12345678",
+      adminChatId: "12345678",
       model: "opus",
       workspace: "/custom/workspace",
       timeZone: "Europe/Prague",
@@ -74,7 +74,7 @@ describe("SettingsManager.load", () => {
     mkdirSync(tmpDir, { recursive: true });
     writeFileSync(join(tmpDir, "settings.json"), JSON.stringify({
       botToken: "tok",
-      chatId: "123",
+      adminChatId: "123",
       model: "opus",
       workspace: "/custom",
       openaiApiKey: "sk-test",
@@ -84,7 +84,7 @@ describe("SettingsManager.load", () => {
     const settings = new SettingsManager(tmpDir).load();
     expect(settings).toEqual({
       botToken: "tok",
-      chatId: "123",
+      adminChatId: "123",
       model: "opus",
       workspace: "/custom",
       timeZone: "UTC",
@@ -114,7 +114,7 @@ describe("SettingsManager.load", () => {
 
   it("exits with code 1 when validation fails (missing required field)", () => {
     mkdirSync(tmpDir, { recursive: true });
-    writeFileSync(join(tmpDir, "settings.json"), JSON.stringify({ chatId: "123" }));
+    writeFileSync(join(tmpDir, "settings.json"), JSON.stringify({ adminChatId: "123" }));
 
     const mockExit = mock(() => { throw new Error("exit"); });
     const origExit = process.exit;
@@ -134,7 +134,7 @@ describe("SettingsManager.load", () => {
     mkdirSync(tmpDir, { recursive: true });
     writeFileSync(join(tmpDir, "settings.json"), JSON.stringify({
       botToken: "tok",
-      chatId: "123",
+      adminChatId: "123",
       logLevel: "verbose",
     }));
 
@@ -156,7 +156,7 @@ describe("SettingsManager.load", () => {
     mkdirSync(tmpDir, { recursive: true });
     writeFileSync(join(tmpDir, "settings.json"), JSON.stringify({
       botToken: "tok",
-      chatId: "123",
+      adminChatId: "123",
       timeZone: "Europe/Prgaaue",
     }));
 
@@ -199,8 +199,14 @@ describe("SettingsManager.loadRaw", () => {
 
   it("reads and parses valid settings file", () => {
     mkdirSync(tmpDir, { recursive: true });
-    writeFileSync(join(tmpDir, "settings.json"), JSON.stringify({ botToken: "tok", chatId: "123" }));
-    expect(new SettingsManager(tmpDir).loadRaw()).toEqual({ botToken: "tok", chatId: "123" });
+    writeFileSync(join(tmpDir, "settings.json"), JSON.stringify({ botToken: "tok", adminChatId: "123" }));
+    expect(new SettingsManager(tmpDir).loadRaw()).toEqual({ botToken: "tok", adminChatId: "123" });
+  });
+
+  it("migrates legacy chatId to adminChatId", () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(join(tmpDir, "settings.json"), JSON.stringify({ botToken: "tok", chatId: "legacy-id" }));
+    expect(new SettingsManager(tmpDir).loadRaw()).toEqual({ botToken: "tok", adminChatId: "legacy-id" });
   });
 
   it("returns null for invalid JSON", () => {
@@ -218,7 +224,7 @@ describe("SettingsManager.loadRaw", () => {
 
 describe("SettingsManager.applyEnvOverrides", () => {
   const envVars = [
-    "TELEGRAM_BOT_TOKEN", "AUTHORIZED_CHAT_ID", "MODEL",
+    "TELEGRAM_BOT_TOKEN", "ADMIN_CHAT_ID", "AUTHORIZED_CHAT_ID", "MODEL",
     "WORKSPACE", "TIMEZONE", "OPENAI_API_KEY", "LOG_LEVEL", "PINORAMA_URL",
   ];
   const savedEnv: Record<string, string | undefined> = {};
@@ -252,13 +258,27 @@ describe("SettingsManager.applyEnvOverrides", () => {
 
   it("overrides multiple fields and tracks them", () => {
     process.env.TELEGRAM_BOT_TOKEN = "override-token";
-    process.env.AUTHORIZED_CHAT_ID = "99999";
+    process.env.ADMIN_CHAT_ID = "99999";
     process.env.OPENAI_API_KEY = "sk-override";
     const { settings, overrides } = new SettingsManager(tmpDir).applyEnvOverrides(validSettings);
     expect(settings.botToken).toBe("override-token");
-    expect(settings.chatId).toBe("99999");
+    expect(settings.adminChatId).toBe("99999");
     expect(settings.openaiApiKey).toBe("sk-override");
     expect(overrides.size).toBe(3);
+  });
+
+  it("falls back to legacy AUTHORIZED_CHAT_ID when ADMIN_CHAT_ID is unset", () => {
+    process.env.AUTHORIZED_CHAT_ID = "88888";
+    const { settings, overrides } = new SettingsManager(tmpDir).applyEnvOverrides(validSettings);
+    expect(settings.adminChatId).toBe("88888");
+    expect(overrides.has("adminChatId")).toBe(true);
+  });
+
+  it("prefers ADMIN_CHAT_ID over legacy AUTHORIZED_CHAT_ID when both set", () => {
+    process.env.ADMIN_CHAT_ID = "111";
+    process.env.AUTHORIZED_CHAT_ID = "222";
+    const { settings } = new SettingsManager(tmpDir).applyEnvOverrides(validSettings);
+    expect(settings.adminChatId).toBe("111");
   });
 
   it("overrides workspace and log-related fields", () => {
@@ -332,7 +352,11 @@ describe("SettingsManager.print", () => {
 describe("SettingsManager.envMapping", () => {
   it("is a static property with all settings keys", () => {
     expect(SettingsManager.envMapping.botToken).toBe("TELEGRAM_BOT_TOKEN");
-    expect(SettingsManager.envMapping.chatId).toBe("AUTHORIZED_CHAT_ID");
+    expect(SettingsManager.envMapping.adminChatId).toBe("ADMIN_CHAT_ID");
     expect(SettingsManager.envMapping.model).toBe("MODEL");
+  });
+
+  it("maps legacy AUTHORIZED_CHAT_ID to adminChatId for migration", () => {
+    expect(SettingsManager.envLegacy.adminChatId).toBe("AUTHORIZED_CHAT_ID");
   });
 });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -8,7 +8,7 @@ const log = createLogger("settings");
 
 export const settingsSchema = z.object({
   botToken: z.string().trim(),
-  chatId: z.string().trim().regex(/^-?\d+$/, "Must be a numeric Telegram chat ID"),
+  adminChatId: z.string().trim().regex(/^-?\d+$/, "Must be a numeric Telegram chat ID"),
   model: z.string().trim().pipe(z.enum(["haiku", "sonnet", "opus"])).default("sonnet"),
   workspace: z.string().trim().default("~/.macroclaw-workspace"),
   timeZone: z.string().trim().refine((tz) => IANAZone.isValidZone(tz), "Must be a valid IANA timezone").default("UTC"),
@@ -29,18 +29,35 @@ export function maskValue(key: string, value: string | undefined): string {
 
 const defaultDir = resolve(process.env.HOME || "~", ".macroclaw");
 
+function migrateLegacy(raw: unknown): unknown {
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    const obj = raw as Record<string, unknown>;
+    if (typeof obj.chatId === "string" && obj.adminChatId === undefined) {
+      const { chatId, ...rest } = obj;
+      log.warn("settings.json uses legacy `chatId` field; migrating to `adminChatId`");
+      return { ...rest, adminChatId: chatId };
+    }
+  }
+  return raw;
+}
+
 export class SettingsManager {
   readonly #dir: string;
 
   static readonly envMapping: Record<keyof Settings, string> = {
     botToken: "TELEGRAM_BOT_TOKEN",
-    chatId: "AUTHORIZED_CHAT_ID",
+    adminChatId: "ADMIN_CHAT_ID",
     model: "MODEL",
     workspace: "WORKSPACE",
     timeZone: "TIMEZONE",
     openaiApiKey: "OPENAI_API_KEY",
     logLevel: "LOG_LEVEL",
     pinoramaUrl: "PINORAMA_URL",
+  };
+
+  /** Legacy env var names still honored as fallbacks for one release. */
+  static readonly envLegacy: Partial<Record<keyof Settings, string>> = {
+    adminChatId: "AUTHORIZED_CHAT_ID",
   };
 
   constructor(dir: string = defaultDir) {
@@ -60,7 +77,7 @@ export class SettingsManager {
 
     let raw: unknown;
     try {
-      raw = JSON.parse(readFileSync(path, "utf-8"));
+      raw = migrateLegacy(JSON.parse(readFileSync(path, "utf-8")));
     } catch {
       raw = null;
     }
@@ -78,8 +95,8 @@ export class SettingsManager {
     const path = join(this.#dir, "settings.json");
     if (!existsSync(path)) return null;
     try {
-      const raw = JSON.parse(readFileSync(path, "utf-8"));
-      return typeof raw === "object" && raw !== null ? raw : null;
+      const raw = migrateLegacy(JSON.parse(readFileSync(path, "utf-8")));
+      return typeof raw === "object" && raw !== null ? (raw as Record<string, unknown>) : null;
     } catch {
       return null;
     }
@@ -99,6 +116,13 @@ export class SettingsManager {
       if (value !== undefined) {
         merged[key] = value;
         overrides.add(key);
+        continue;
+      }
+      const legacy = SettingsManager.envLegacy[key as keyof Settings];
+      if (legacy && process.env[legacy] !== undefined) {
+        merged[key] = process.env[legacy];
+        overrides.add(key);
+        log.warn({ legacy, preferred: envVar }, "using legacy env var; rename to the new one");
       }
     }
 

--- a/src/setup.test.ts
+++ b/src/setup.test.ts
@@ -46,6 +46,12 @@ mock.module("grammy", () => ({
       await mockBotStop();
     }
   },
+  InlineKeyboard: class {
+    inline_keyboard: never[] = [];
+    text() { return this; }
+    row() { return this; }
+  },
+  InputFile: class { constructor(public path: string) {} },
 }));
 
 const mockInstall = mock(() => "tail -f /mock/logs");

--- a/src/setup.test.ts
+++ b/src/setup.test.ts
@@ -79,7 +79,7 @@ function createMockIO(inputs: string[]): SetupIo & { written: string[] } {
 }
 
 // Save/restore env vars
-const envVars = ["TELEGRAM_BOT_TOKEN", "AUTHORIZED_CHAT_ID", "MODEL", "WORKSPACE", "TIMEZONE", "OPENAI_API_KEY", "LOG_LEVEL"];
+const envVars = ["TELEGRAM_BOT_TOKEN", "ADMIN_CHAT_ID", "MODEL", "WORKSPACE", "TIMEZONE", "OPENAI_API_KEY", "LOG_LEVEL"];
 const savedEnv: Record<string, string | undefined> = {};
 
 beforeEach(() => {
@@ -119,7 +119,7 @@ describe("SetupWizard", () => {
     const settings = await runSetup(io);
 
     expect(settings.botToken).toBe("123:ABC");
-    expect(settings.chatId).toBe("12345678");
+    expect(settings.adminChatId).toBe("12345678");
     expect(settings.model).toBe("opus");
     expect(settings.workspace).toBe("/my/ws");
     expect(settings.timeZone).toBe("Europe/Prague");
@@ -129,7 +129,7 @@ describe("SetupWizard", () => {
 
   it("uses defaults from env vars when user presses enter", async () => {
     process.env.TELEGRAM_BOT_TOKEN = "env-token";
-    process.env.AUTHORIZED_CHAT_ID = "99887766";
+    process.env.ADMIN_CHAT_ID = "99887766";
     process.env.MODEL = "haiku";
     process.env.WORKSPACE = "/env/ws";
     process.env.TIMEZONE = "America/New_York";
@@ -148,7 +148,7 @@ describe("SetupWizard", () => {
     const settings = await runSetup(io);
 
     expect(settings.botToken).toBe("env-token");
-    expect(settings.chatId).toBe("99887766");
+    expect(settings.adminChatId).toBe("99887766");
     expect(settings.model).toBe("haiku");
     expect(settings.workspace).toBe("/env/ws");
     expect(settings.timeZone).toBe("America/New_York");
@@ -246,7 +246,7 @@ describe("SetupWizard", () => {
 
     const settings = await runSetup(io);
 
-    expect(settings.chatId).toBe("456");
+    expect(settings.adminChatId).toBe("456");
   });
 
   it("re-prompts when chat ID is not numeric", async () => {
@@ -263,7 +263,7 @@ describe("SetupWizard", () => {
 
     const settings = await runSetup(io);
 
-    expect(settings.chatId).toBe("456");
+    expect(settings.adminChatId).toBe("456");
     expect(io.written).toContainEqual(expect.stringContaining("Invalid value"));
   });
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -66,7 +66,7 @@ export class SetupWizard {
       // Admin chat ID
       this.#io.write("Next, we need the admin chat ID. This is the bootstrap chat with full\n");
       this.#io.write("control — send /chatid to the bot in Telegram to get yours. Additional\n");
-      this.#io.write("chats can be authorized at runtime via /chats-add from the admin chat.\n\n");
+      this.#io.write("chats can be authorized at runtime via /chatsadd from the admin chat.\n\n");
       const defaultAdminChatId = this.#default("adminChatId");
       const adminChatIdPrompt = defaultAdminChatId ? `Admin chat ID [${defaultAdminChatId}]: ` : "Admin chat ID: ";
       const adminChatId = await this.#askValidated("adminChatId", adminChatIdPrompt, defaultAdminChatId);

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -63,12 +63,13 @@ export class SetupWizard {
       this.#io.write("  3. Copy the token it gives you (looks like 123456:ABC-DEF...)\n\n");
       const { botToken, bot } = await this.#askBotToken();
 
-      // Chat ID
-      this.#io.write("Next, we need a chat ID. Macroclaw only accepts messages from a single\n");
-      this.#io.write("authorized chat — send /chatid to the bot in Telegram to get yours.\n\n");
-      const defaultChatId = this.#default("chatId");
-      const chatIdPrompt = defaultChatId ? `Chat ID [${defaultChatId}]: ` : "Chat ID: ";
-      const chatId = await this.#askValidated("chatId", chatIdPrompt, defaultChatId);
+      // Admin chat ID
+      this.#io.write("Next, we need the admin chat ID. This is the bootstrap chat with full\n");
+      this.#io.write("control — send /chatid to the bot in Telegram to get yours. Additional\n");
+      this.#io.write("chats can be authorized at runtime via /chats-add from the admin chat.\n\n");
+      const defaultAdminChatId = this.#default("adminChatId");
+      const adminChatIdPrompt = defaultAdminChatId ? `Admin chat ID [${defaultAdminChatId}]: ` : "Admin chat ID: ";
+      const adminChatId = await this.#askValidated("adminChatId", adminChatIdPrompt, defaultAdminChatId);
 
       // Stop setup bot after chat ID is collected
       await bot.stop();
@@ -103,7 +104,7 @@ export class SetupWizard {
 
       const settings: Settings = settingsSchema.parse({
         botToken,
-        chatId,
+        adminChatId,
         model,
         workspace,
         timeZone,

--- a/workspace-template/.claude/skills/schedule-event/SKILL.md
+++ b/workspace-template/.claude/skills/schedule-event/SKILL.md
@@ -21,10 +21,21 @@ Schedule a new event by adding it to `data/schedule.json`.
 3. Determine job type:
    - **Recurring** → convert to a cron expression in local time. See reference below.
    - **One-time** → compute an ISO 8601 timestamp with the user's timezone offset for `fireAt`
-4. **Be proactive about timing**: if the user says "next week" or "tomorrow" without a specific time, pick the best time based on what you know (their routine, calendar, context)
-5. Append the new job to the `jobs` array
-6. Write the updated file
-7. Confirm: what was scheduled, when it will fire, and offer to adjust
+4. **Route the job to a chat via the `chat` field** — see [Chat routing](#chat-routing) below. When scheduling from a conversation, target the chat the user is talking to you in (read the `<event chat="...">` attribute on the incoming event).
+5. **Be proactive about timing**: if the user says "next week" or "tomorrow" without a specific time, pick the best time based on what you know (their routine, calendar, context)
+6. Append the new job to the `jobs` array
+7. Write the updated file
+8. Confirm: what was scheduled, when it will fire, and offer to adjust
+
+## Chat routing
+
+Every incoming `<event>` has a `chat="<name>"` attribute identifying which chat it came from (e.g. `admin`, `family`). When a scheduled job fires, the bridge delivers the response to the chat named in the job's `chat` field.
+
+- **Default (no `chat` field)** — response goes to the admin chat.
+- **Explicit chat name** — e.g. `"chat": "family"`. Response goes to that chat.
+- **Broadcast** — `"chat": "*"`. The same prompt runs once per authorized chat, and each response is delivered to that chat. Use sparingly — only for genuinely universal reminders.
+
+When the user asks you to schedule something, set `chat` to the chat name from the incoming event's `chat` attribute so the reminder comes back to the same chat. Don't omit `chat` unless you know the job should reach the admin chat specifically.
 
 ## Natural language → job format
 
@@ -52,18 +63,27 @@ Two job types, discriminated by field:
     {
       "name": "morning-summary",
       "cron": "0 7 * * 1-5",
-      "prompt": "Give me a morning summary of my tasks"
+      "prompt": "Give me a morning summary of my tasks",
+      "chat": "admin"
+    },
+    {
+      "name": "family-dinner-poll",
+      "cron": "0 17 * * 5",
+      "prompt": "Ask what everyone wants for dinner",
+      "chat": "family"
     },
     {
       "name": "email-check",
       "cron": "*/30 * * * *",
       "prompt": "Check if any important emails arrived",
-      "model": "haiku"
+      "model": "haiku",
+      "chat": "admin"
     },
     {
       "name": "dentist-reminder",
       "fireAt": "2026-03-15T08:00:00",
-      "prompt": "Reminder: call the dentist to reschedule your appointment"
+      "prompt": "Reminder: call the dentist to reschedule your appointment",
+      "chat": "admin"
     }
   ]
 }
@@ -77,6 +97,7 @@ Two job types, discriminated by field:
 | `cron` | for recurring | Standard cron expression (local time). See reference below. |
 | `fireAt` | for one-time | ISO 8601 timestamp (e.g. `2026-03-15T08:00:00`). Can include a timezone offset (e.g. `2026-03-15T08:00:00+01:00`); without one, the time is interpreted in the configured timezone. |
 | `prompt` | yes | The message sent to the agent when the event fires. Write it as a natural instruction. |
+| `chat` | no | Name of the chat to deliver the response to (e.g. `admin`, `family`). Defaults to `admin`. Use `"*"` to broadcast the prompt to every authorized chat. Match the `chat` attribute from the incoming `<event>` when scheduling from a conversation. |
 | `model` | no | Override the model. Use `haiku` for cheap checks, `opus` for complex reasoning. Omit for default. |
 
 Each job must have exactly one of `cron` or `fireAt` (not both).

--- a/workspace-template/data/schedule.json
+++ b/workspace-template/data/schedule.json
@@ -4,12 +4,14 @@
       "name": "memory-capture",
       "cron": "0 */4 * * *",
       "model": "haiku",
+      "chat": "*",
       "prompt": "Append today's noteworthy events to memory/YYYY-MM-DD.md (create the file and directory if needed). Add a ## HH:MM heading with bullet points underneath. Capture: decisions made, facts learned, user preferences expressed, tasks completed or started, problems solved. Be factual and concise — one line per item. If the file already exists, APPEND only — never overwrite. If nothing meaningful happened since the last entry, respond silently."
     },
     {
       "name": "memory-consolidate",
       "cron": "0 3 * * *",
       "model": "opus",
+      "chat": "admin",
       "prompt": "Read daily logs in memory/ from the past 3 days. Distill durable knowledge into MEMORY.md: confirmed facts, recurring patterns, stable preferences, key decisions, and important context. Remove entries from MEMORY.md that are outdated or contradicted by recent logs. Keep MEMORY.md concise and organized by topic (not chronologically). Do not duplicate entries. If daily logs contain new personal facts about the user (preferences, routines, family, work, interests), update USER.md accordingly. Respond silently."
     }
   ]


### PR DESCRIPTION
Closes #91

## Summary

- **sessions**: session map keyed by chat name instead of a single `mainSessionId` (with legacy migration)
- **settings**: rename `chatId` → `adminChatId`; `AUTHORIZED_CHAT_ID` env var still accepted as fallback
- **authorized-chats**: new module (`AuthorizedChats`) to load/persist authorized chat list at runtime
- **app**: one `Orchestrator` per chat in a `Map<chatId, Orchestrator>`; incoming messages routed by chatId
- **commands**: `/chats`, `/chatsadd <chatId> <name>`, `/chatsremove [name]` — names use Telegram-valid characters (no hyphens). Behaviour:
  - `/chats` — admin only, lists authorized chats
  - `/chatsadd` — admin only, creates the Orchestrator and sessions slot
  - `/chatsremove <name>` — admin only, disposes the Orchestrator and clears sessions
  - `/chatsremove` (no arg, from admin) — shows a pick-list button for each authorized chat
  - `/chatsremove` (no arg, from an authorized non-admin chat) — self-removal
- **scheduler**: per-job `chat` field; `undefined` → admin, `"*"` → broadcast to all orchestrators; `App.handleCron` is the public routing entrypoint (no test-only `schedulerFactory`)
- **prompt-builder**: mandatory `chatName` constructor arg, rendered as `chat="..."` attribute on every `<event>` element. System prompt documents the multi-chat model and the chat attribute so the agent tailors responses per chat

## Test plan

- [ ] All tests pass with 100% line coverage (`bun run check`)
- [ ] Smoke-test: add a secondary chat with `/chatsadd`, send a message, verify it gets a response
- [ ] Admin `/chatsremove` with no arg shows chat-picker buttons
- [ ] Button-based removal disposes the orchestrator and clears its session
- [ ] Non-admin authorized chat: `/chatsremove` (no arg) self-removes
- [ ] Cron job with `chat: "*"` broadcasts to all authorized chats
- [ ] Existing admin chat continues working after upgrade (legacy session migration)